### PR TITLE
Changed failure handling of the agent overlay module.

### DIFF
--- a/overlay/messages.proto
+++ b/overlay/messages.proto
@@ -51,6 +51,9 @@ message AgentNetworkConfig {
   // however to support GCE we are setting the default MTU value to
   // 1420 bytes.
   optional uint32 overlay_mtu = 4 [default = 1420];
+  optional string ipset = 5 [default = "ipset"];
+  optional string iptables = 6 [default = "iptables"];
+  optional string docker = 7 [default = "docker"];
 }
 
 


### PR DESCRIPTION
The PR contains the following changes:
a) Introduced a timeout for all invocations to the docker daemon.
b) Also introduced an `onDiscard` callback to `Subprocess` invocations, to kill the subprocess when the callee discards the future.
c) Have introduced new fields in the agent configuration in order to allow the operator to specify the location of the `ipset`, `iptabels` and `docker` binaries. This also  helps us in emulating failures of these binaries during unit-tests.
d) Introduced a temp directory for CNI configuration. Since, now we are allowing the overlay module to progress even if the overlay configuration has not been successful, we need to ensure that the CNI config is installed only after successful overlay configuration. To achieve this we introduce a temp directory where the CNI configuration is installed. The CNI configuration is moved from the temp location to the CNI config directory once the overlay configuration is successful.