### PR TITLE
Adds an anonymous module which redirects glog output.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,20 @@ mesos_journald_logger_LDFLAGS =				\
   $(SYSTEMD_JOURNALD)
 
 ###############################################################################
+# LogSink Anonymous Module.
+###############################################################################
+
+# Library with the LogSink module.
+pkglib_LTLIBRARIES += liblogsink.la
+liblogsink_la_SOURCES =					\
+  logsink/logsink.hpp					\
+  logsink/logsink.cpp
+
+liblogsink_la_LDFLAGS =					\
+  -release $(PACKAGE_VERSION)				\
+  -shared $(MESOS_LDFLAGS)
+
+###############################################################################
 # Overlay Modules.
 ###############################################################################
 
@@ -181,6 +195,22 @@ test_journald_LDADD =					\
   libmesos_tests.la					\
   libjournaldlogger.la
 
+# Test (make check) binary for the LogSink module.
+check_PROGRAMS += test-logsink
+
+test_logsink_SOURCES =					\
+  tests/logsink_tests.cpp
+
+test_logsink_CPPFLAGS =					\
+  $(libmesos_tests_la_CPPFLAGS)
+
+test_logsink_LDADD =					\
+  $(MESOS_LDFLAGS)					\
+  $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/.libs/libgmock.la	\
+  $(MESOS_BUILD_DIR)/src/.libs/libmesos.la		\
+  libmesos_tests.la					\
+  liblogsink.la
+
 # Test (make check) binary for the overlay modules.
 check_PROGRAMS += test-overlay
 
@@ -201,4 +231,5 @@ endif
 check-local: $(check_PROGRAMS)
 	./test-dockercfg
 	./test-journald --verbose
+	./test-logsink --verbose
 	LIBPROCESS_IP=127.0.0.1 LIBPROCESS_PORT=5050 ./test-overlay --verbose

--- a/configure.ac
+++ b/configure.ac
@@ -361,6 +361,7 @@ fi
 # Create Modules JSON blobs.
 AC_CONFIG_FILES([dockercfg/modules.json], [])
 AC_CONFIG_FILES([journald/modules.json], [])
+AC_CONFIG_FILES([logsink/modules.json], [])
 AC_CONFIG_FILES([overlay/agent_modules.json], [])
 AC_CONFIG_FILES([overlay/master_modules.json], [])
 

--- a/logsink/logsink.cpp
+++ b/logsink/logsink.cpp
@@ -1,0 +1,136 @@
+#include <string>
+
+#include <glog/logging.h>
+
+#include <mesos/mesos.hpp>
+#include <mesos/module.hpp>
+#include <mesos/module/anonymous.hpp>
+
+#include <process/owned.hpp>
+
+#include <stout/os.hpp>
+
+#include <stout/os/close.hpp>
+#include <stout/os/exists.hpp>
+#include <stout/os/mkdir.hpp>
+#include <stout/os/open.hpp>
+#include <stout/os/write.hpp>
+
+#include "logsink.hpp"
+
+
+using mesos::Parameter;
+using mesos::Parameters;
+
+using mesos::modules::Anonymous;
+using mesos::modules::Module;
+
+namespace mesos {
+namespace logsink {
+
+
+FileSink::FileSink(const Flags& _flags) : flags(_flags)
+{
+  if (!os::exists(flags.output_file)) {
+    // Create the log directory (noop if it already exists).
+    CHECK_SOME(os::mkdir(Path(flags.output_file).dirname()));
+  }
+
+  // Open the file in append mode (or create it if it doesn't exist).
+  Try<int> open = os::open(
+      flags.output_file,
+      O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC,
+      S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  CHECK_SOME(open);
+
+  logFd = open.get();
+}
+
+
+FileSink::~FileSink()
+{
+  os::close(logFd);
+}
+
+
+void FileSink::send(
+    google::LogSeverity severity,
+    const char* full_filename,
+    const char* base_filename,
+    int line,
+    const struct ::tm* tm_time,
+    const char* message,
+    size_t message_len)
+{
+  os::write(
+      logFd,
+      ToString(
+          severity,
+          base_filename,
+          line,
+          tm_time,
+          message,
+          // NOTE: The LogSink's message length excludes the newline.
+          message_len + 1));
+}
+
+
+void FileSink::WaitTillSent() {}
+
+
+// An anonymous module that owns and hooks up a new LogSink to glog.
+class AnonymousWrapper : public Anonymous
+{
+public:
+  AnonymousWrapper(const Flags& flags) : sink(new FileSink(flags))
+  {
+    google::AddLogSink(sink.get());
+
+    LOG(INFO) << "Added FileSink for glog logs to: " << flags.output_file;
+  };
+
+  ~AnonymousWrapper()
+  {
+    google::RemoveLogSink(sink.get());
+
+    LOG(INFO) << "Removed FileSink for glog logs";
+  };
+
+protected:
+  process::Owned<FileSink> sink;
+};
+
+} // namespace mesos {
+} // namespace logsink {
+
+
+Module<Anonymous> com_mesosphere_mesos_LogSink(
+    MESOS_MODULE_API_VERSION,
+    MESOS_VERSION,
+    "Mesosphere",
+    "help@mesosphere.io",
+    "Mesos LogSink Anonymous Module",
+    NULL,
+    [](const Parameters& parameters) -> Anonymous* {
+      // Convert `parameters` into a map.
+      std::map<std::string, std::string> values;
+      foreach (const Parameter& parameter, parameters.parameter()) {
+        values[parameter.key()] = parameter.value();
+      }
+
+      // Load and validate flags from the map.
+      mesos::logsink::Flags flags;
+      Try<flags::Warnings> load = flags.load(values);
+
+      if (load.isError()) {
+        LOG(ERROR) << "Failed to parse parameters: " << load.error();
+        return nullptr;
+      }
+
+      // Log any flag warnings.
+      foreach (const flags::Warning& warning, load->warnings) {
+        LOG(WARNING) << warning.message;
+      }
+
+      return new mesos::logsink::AnonymousWrapper(flags);
+    });

--- a/logsink/logsink.hpp
+++ b/logsink/logsink.hpp
@@ -1,0 +1,63 @@
+#ifndef __LOGSINK_LOGSINK_HPP__
+#define __LOGSINK_LOGSINK_HPP__
+
+#include <mutex>
+#include <string>
+
+#include <glog/logging.h>
+
+#include <stout/flags.hpp>
+#include <stout/synchronized.hpp>
+
+
+namespace mesos {
+namespace logsink {
+
+class FileSinkProcess;
+
+struct Flags : public virtual flags::FlagsBase
+{
+  Flags()
+  {
+    add(&Flags::output_file,
+        "output_file",
+        "Where the LogSink should write all logs.\n"
+        "If the file already exists, we will append to the file.\n"
+        "If no file exists, a new one will be created.");
+  }
+
+  std::string output_file;
+};
+
+
+// A glog LogSink that writes logs to a file.
+// We do not use glog's native file-writing capabilities as we prefer
+// to control the naming conventions of log files and how logs are rotated.
+class FileSink : public google::LogSink
+{
+public:
+  FileSink(const Flags& _flags);
+
+  ~FileSink();
+
+  virtual void send(
+      google::LogSeverity severity,
+      const char* full_filename,
+      const char* base_filename,
+      int line,
+      const struct ::tm* tm_time,
+      const char* message,
+      size_t message_len);
+
+  virtual void WaitTillSent();
+
+protected:
+  Flags flags;
+  int logFd;
+  std::recursive_mutex mutex;
+};
+
+} // namespace logsink {
+} // namespace mesos {
+
+#endif // __LOGSINK_LOGSINK_HPP__

--- a/logsink/modules.json.in
+++ b/logsink/modules.json.in
@@ -1,0 +1,12 @@
+{
+  "libraries": [
+    {
+      "file": "@abs_top_builddir@/.libs/liblogsink.@LIB_EXT@",
+      "modules": [
+        {
+          "name": "com_mesosphere_mesos_LogSink"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/logsink_tests.cpp
+++ b/tests/logsink_tests.cpp
@@ -1,0 +1,222 @@
+#include <list>
+#include <string>
+
+#include <gmock/gmock.h>
+
+#include <mesos/mesos.hpp>
+
+#include <mesos/module/anonymous.hpp>
+#include <mesos/module/module.hpp>
+
+#include <process/clock.hpp>
+#include <process/dispatch.hpp>
+#include <process/future.hpp>
+#include <process/gmock.hpp>
+#include <process/gtest.hpp>
+#include <process/owned.hpp>
+#include <process/process.hpp>
+
+#include <stout/duration.hpp>
+#include <stout/gtest.hpp>
+#include <stout/os.hpp>
+#include <stout/path.hpp>
+#include <stout/strings.hpp>
+
+#include <stout/os/exists.hpp>
+#include <stout/os/read.hpp>
+
+#include "hook/manager.hpp"
+
+#include "module/manager.hpp"
+
+#include "tests/mesos.hpp"
+
+
+using namespace mesos::internal::tests;
+
+using process::Owned;
+
+using mesos::Parameter;
+using mesos::Parameters;
+
+using mesos::modules::Anonymous;
+using mesos::modules::ModuleManager;
+
+namespace mesos {
+namespace logsink {
+namespace tests {
+
+
+class LogSinkTest : public MesosTest
+{
+protected:
+  virtual void SetUp()
+  {
+    MesosTest::SetUp();
+
+    logFile = path::join(sandbox.get(), "test.log");
+
+    // Read in the example `modules.json`.
+    Try<std::string> read =
+      os::read(path::join(MODULES_BUILD_DIR, "logsink", "modules.json"));
+    ASSERT_SOME(read);
+
+    Try<JSON::Object> json = JSON::parse<JSON::Object>(read.get());
+    ASSERT_SOME(json);
+
+    Try<Modules> _modules = protobuf::parse<Modules>(json.get());
+    ASSERT_SOME(_modules);
+
+    modules = _modules.get();
+
+    // Add the test's sandbox to the module's parameters.
+    Parameter* parameter =
+      modules.mutable_libraries(0)->mutable_modules(0)->add_parameters();
+    parameter->set_key("output_file");
+    parameter->set_value(logFile);
+
+    // Initialize the modules.
+    Try<Nothing> result = ModuleManager::load(modules);
+    ASSERT_SOME(result);
+
+    // Create anonymous modules.
+    // This is approximately how the Mesos master
+    // and agent load anonymous modules.
+    foreach (const string& name, ModuleManager::find<Anonymous>()) {
+      LOG(INFO) << "Loading module: " << name;
+
+      Try<Anonymous*> create = ModuleManager::create<Anonymous>(name);
+      if (create.isError()) {
+        EXIT(EXIT_FAILURE)
+          << "Failed to create anonymous module named '" << name << "'";
+      }
+
+      anonymouses.push_back(Owned<Anonymous>(create.get()));
+    }
+  }
+
+  virtual void TearDown()
+  {
+    // Unload all modules.
+    foreach (const Modules::Library& library, modules.libraries()) {
+      foreach (const Modules::Library::Module& module, library.modules()) {
+        if (module.has_name()) {
+          ASSERT_SOME(ModuleManager::unload(module.name()));
+        }
+      }
+    }
+
+    anonymouses.clear();
+
+    MesosTest::TearDown();
+  }
+
+protected:
+  std::string logFile;
+
+private:
+  Modules modules;
+  std::list<Owned<Anonymous>> anonymouses;
+};
+
+
+// Writes a line to glog and checks the `FileSink`s output file
+// for the same string.
+TEST_F(LogSinkTest, LogSomething)
+{
+  // Wait for the log file to be created.
+  // This happens asynchronously as the anonymous module is created
+  // in a nonblocking fashion.
+  Duration waited = Duration::zero();
+  do {
+    if (os::exists(logFile)) {
+      break;
+    }
+
+    os::sleep(Milliseconds(100));
+    waited += Milliseconds(100);
+  } while (waited < Seconds(2));
+
+  ASSERT_TRUE(os::exists(logFile));
+
+  // Now wait for the log sink to write a line that
+  // effectively tells us that the sink has been hooked up.
+  const std::string logReadyString = "Added FileSink for glog logs";
+  Try<std::string> logContents = os::read(logFile);
+  ASSERT_SOME(logContents);
+
+  waited = Duration::zero();
+  while (waited < Seconds(2)) {
+    if (strings::contains(logContents.get(), logReadyString)) {
+      break;
+    }
+
+    os::sleep(Milliseconds(100));
+    waited += Milliseconds(100);
+
+    logContents = os::read(logFile);
+    ASSERT_SOME(logContents);
+  }
+
+  ASSERT_TRUE(strings::contains(logContents.get(), logReadyString));
+
+  const std::string logString = "This should appear in the log file";
+  LOG(INFO) << logString;
+
+  // Check that the log contains our special line.
+  logContents = os::read(logFile);
+  ASSERT_SOME(logContents);
+
+  ASSERT_TRUE(strings::contains(logContents.get(), logString));
+}
+
+
+class SpamProcess : public process::Process<SpamProcess>
+{
+public:
+  SpamProcess() {}
+
+  process::Future<Nothing> spam()
+  {
+    LOG(INFO) << "Spam!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!";
+
+    process::dispatch(self(), &SpamProcess::spam);
+
+    return Nothing();
+  }
+};
+
+
+// Spawns a bunch of actors that spam the log for a while.
+// This test is used to detect deadlock in the LogSink
+// and to check for interleaving in the logs.
+TEST_F(LogSinkTest, LogStress)
+{
+  std::list<process::UPID> spammers;
+  for (int i = 0; i < 100; i++) {
+    process::PID<SpamProcess> spammer =
+      process::spawn(new SpamProcess(), true);
+
+    spammers.push_back(spammer);
+
+    process::dispatch(spammer, &SpamProcess::spam);
+  }
+
+  Try<std::string> logContents = os::read(logFile);
+  ASSERT_SOME(logContents);
+
+  // Let the spammers run for a while.
+  os::sleep(Seconds(2));
+
+  foreach (const process::UPID& spammer, spammers) {
+    process::terminate(spammer);
+  }
+
+  foreach (const process::UPID& spammer, spammers) {
+    process::wait(spammer);
+  }
+}
+
+} // namespace tests {
+} // namespace logsink {
+} // namespace mesos {


### PR DESCRIPTION
The glog library exposes a `LogSink` interface which can be used to consume logs and direct them to some arbitrary location.  

This module simply prints the logs to a single configurable file.  (This is much simpler than glog's option of writing logs to a directory with some built-in log rotation and verbose log names.)
Logging to stderr is not affected.