### PR TITLE
Restructure of the overlay agent module.

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -863,11 +863,6 @@ Manager::Manager(const Owned<ManagerProcess>& _process)
 {
   spawn(process.get());
 
-  // Wait for the overlay-manager to be ready before
-  // allowing the Agent to proceed.
-  Future<Nothing> ready = process->ready();
-  ready.await();
-
   LOG(INFO) << "Overlay agent is ready";
 }
 

--- a/overlay/agent.hpp
+++ b/overlay/agent.hpp
@@ -1,0 +1,120 @@
+#ifndef __AGENT_OVERLAY_MANAGER_HPP__
+#define __AGENT_OVERLAY_MANAGER_HPP__
+
+#include <process/future.hpp>
+#include <process/http.hpp>
+#include <process/process.hpp>
+#include <process/protobuf.hpp>
+
+#include <mesos/master/detector.hpp>
+#include <mesos/mesos.hpp>
+#include <mesos/module/anonymous.hpp>
+
+#include <overlay/messages.hpp>
+
+namespace mesos {
+namespace modules {
+namespace overlay {
+namespace agent {
+
+class ManagerProcess : public ProtobufProcess<ManagerProcess>
+{
+public:
+  static Try<process::Owned<ManagerProcess>> create(
+      const overlay::internal::AgentConfig& agentConfig);
+
+  process::Future<Nothing> ready();
+
+protected:
+  void agentRegisteredAcknowledgement(const process::UPID& from);
+
+  void detected(const process::Future<Option<MasterInfo>>& mesosMaster);
+
+  void doReliableRegistration(Duration maxBackoff);
+
+  virtual void exited(const process::UPID& pid);
+
+  virtual void initialize();
+
+  process::Future<process::http::Response> overlay(
+      const process::http::Request& request);
+
+  process::Future<Nothing> configure(const std::string& name);
+
+  process::Future<Nothing> _configure(
+      const std::string& name,
+      const std::tuple<process::Future<Nothing>, process::Future<Nothing>>& t);
+
+  process::Future<Nothing> configureMesosNetwork(const std::string& name);
+
+  process::Future<Nothing> configureDockerNetwork(const std::string& name);
+
+  process::Future<Nothing> _configureDockerNetwork(const std::string& name, bool exists);
+
+  process::Future<Nothing> __configureDockerNetwork(
+      const std::string& name,
+      const process::Future<std::string> &result);
+
+  process::Future<bool> checkDockerNetwork(const std::string& name);
+
+  void updateAgentOverlays(
+      const process::UPID& from,
+      const overlay::internal::UpdateAgentOverlaysMessage& message);
+
+  void _updateAgentOverlays(
+      const process::Future<std::list<process::Future<Nothing>>>& results);
+
+private:
+  enum State
+  {
+    REGISTERING = 0,
+    REGISTERED = 1,
+    CONFIGURING = 2
+  };
+
+  ManagerProcess(
+      const std::string& _cniDir,
+      const overlay::internal::AgentNetworkConfig _networkConfig,
+      const uint32_t _maxConfigAttempts,
+      process::Owned<master::detector::MasterDetector> _detector);
+
+  const std::string cniDir;
+
+  const overlay::internal::AgentNetworkConfig networkConfig;
+
+  State state;
+
+  process::Promise<Nothing> connected;
+
+  Option<process::UPID> overlayMaster;
+
+  hashmap<std::string, overlay::AgentOverlayInfo> overlays;
+
+  const uint32_t maxConfigAttempts;
+
+  uint32_t configAttempts;
+
+  process::Owned<master::detector::MasterDetector> detector;
+};
+
+
+class Manager : public Anonymous
+{
+public:
+  static Try<Manager*> create(
+      const overlay::internal::AgentConfig& agentConfig);
+
+  virtual ~Manager();
+
+private:
+  Manager(const process::Owned<ManagerProcess>& _process);
+
+  process::Owned<ManagerProcess> process;
+};
+
+} // namespace agent {
+} // namespace overlay {
+} // namespace modules {
+} // namespace mesos {
+
+#endif // __AGENT_OVERLAY_MANAGER_HPP__

--- a/tests/overlay_tests.cpp
+++ b/tests/overlay_tests.cpp
@@ -482,11 +482,13 @@ TEST_F(OverlayTest, checkMasterAgentComm)
 
   Try<net::IPNetwork> agentNetwork = net::IPNetwork::parse(
       info->overlays(0).subnet(), AF_INET);
+
   ASSERT_SOME(agentNetwork);
   EXPECT_EQ(24, agentNetwork->prefix());
 
   Try<net::IPNetwork> allocatedSubnet = net::IPNetwork::parse(
       "192.168.0.0/24", AF_INET);
+
   ASSERT_SOME(allocatedSubnet);
   EXPECT_EQ(allocatedSubnet.get(), agentNetwork.get());
 
@@ -501,6 +503,7 @@ TEST_F(OverlayTest, checkMasterAgentComm)
       APPLICATION_JSON,
       "Content-Type",
       masterResponse);
+
   state = parseMasterState(masterResponse->body);
   ASSERT_SOME(state);
   ASSERT_EQ(1, state->agents_size());
@@ -573,6 +576,7 @@ TEST_F(OverlayTest, ROOT_checkMesosNetwork)
   // Verify the CNI configuration has been installed correctly.
   Try<string> cniConfig = os::read(
       path::join("cni", stringify(OVERLAY_NAME) + ".cni"));
+
   ASSERT_SOME(cniConfig);
 
   Try<JSON::Object> json = JSON::parse<JSON::Object>(cniConfig.get());
@@ -642,6 +646,7 @@ TEST_F(OverlayTest, ROOT_checkDockerNetwork)
       {"ipset",
       "list",
       IPSET_OVERLAY});
+
   AWAIT_READY(ipset);
 
   // Verify that the `IPMASQ` rules have been installed.
@@ -654,6 +659,7 @@ TEST_F(OverlayTest, ROOT_checkDockerNetwork)
       "--match-set", stringify(IPSET_OVERLAY), "dst",
       "-j", "MASQUERADE",
       });
+
   AWAIT_READY(iptables);
 
   // Verify the docker network has been installed correctly.
@@ -662,6 +668,7 @@ TEST_F(OverlayTest, ROOT_checkDockerNetwork)
       "network",
       "inspect",
       OVERLAY_NAME});
+
   AWAIT_READY(docker);
 
   Try<JSON::Array> json = JSON::parse<JSON::Array>(docker.get());
@@ -743,11 +750,13 @@ TEST_F(OverlayTest, ROOT_checkMasterRecovery)
 
   Try<net::IPNetwork> agentNetwork = net::IPNetwork::parse(
       info->overlays(0).subnet(), AF_INET);
+
   ASSERT_SOME(agentNetwork);
   EXPECT_EQ(24, agentNetwork->prefix());
 
   Try<net::IPNetwork> allocatedSubnet = net::IPNetwork::parse(
       "192.168.0.0/24", AF_INET);
+
   ASSERT_SOME(allocatedSubnet);
   EXPECT_EQ(allocatedSubnet.get(), agentNetwork.get());
 
@@ -773,7 +782,7 @@ TEST_F(OverlayTest, ROOT_checkMasterRecovery)
       info.get().SerializeAsString(),
       masterAgentInfo.SerializeAsString())
       << "Agent response: " << agentResponse->body
-      << " Master response: " << masterResponse->body;
+      << ", Master response: " << masterResponse->body;
 
   // Kill the master.
   masterModule->reset();
@@ -784,6 +793,7 @@ TEST_F(OverlayTest, ROOT_checkMasterRecovery)
   // Re-start the master and wait for the Agent to re-register.
   agentRegisteredAcknowledgement = FUTURE_PROTOBUF(
       AgentRegisteredAcknowledgement(), _, _);
+
   AWAIT_READY(agentRegisteredAcknowledgement);
 
   // Hit the master end-point again.
@@ -883,17 +893,20 @@ TEST_F(OverlayTest, ROOT_checkAgentRecovery)
 
   Try<net::IPNetwork> agentNetwork = net::IPNetwork::parse(
       info->overlays(0).subnet(), AF_INET);
+
   ASSERT_SOME(agentNetwork);
   EXPECT_EQ(24, agentNetwork->prefix());
 
   Try<net::IPNetwork> allocatedSubnet = net::IPNetwork::parse(
       "192.168.0.0/24", AF_INET);
+
   ASSERT_SOME(allocatedSubnet);
   EXPECT_EQ(allocatedSubnet.get(), agentNetwork.get());
 
   // Re-start the agent and wait for the agent to re-register.
   Future<AgentRegisteredAcknowledgement> agentReRegisteredAcknowledgement =
     FUTURE_PROTOBUF(AgentRegisteredAcknowledgement(), _, _);
+
   // Kill the agent.
   Try<Nothing> stop = stopOverlayAgent();
   ASSERT_SOME(stop);
@@ -999,11 +1012,13 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
 
   Try<net::IPNetwork> agentNetwork = net::IPNetwork::parse(
       info->overlays(0).subnet(), AF_INET);
+
   ASSERT_SOME(agentNetwork);
   EXPECT_EQ(24, agentNetwork->prefix());
 
   Try<net::IPNetwork> allocatedSubnet = net::IPNetwork::parse(
       "192.168.0.0/24", AF_INET);
+
   ASSERT_SOME(allocatedSubnet);
   EXPECT_EQ(allocatedSubnet.get(), agentNetwork.get());
 
@@ -1021,6 +1036,7 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
       "--match-set", stringify(IPSET_OVERLAY), "dst",
       "-j", "MASQUERADE",
       });
+
   AWAIT_READY(iptables);
 
   // Delete the IPMASQ rules.
@@ -1033,6 +1049,7 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
       "--match-set", stringify(IPSET_OVERLAY), "dst",
       "-j", "MASQUERADE",
       });
+
   AWAIT_READY(iptables);
 
   // Re-start the agent and wait for the agent to re-register.
@@ -1064,6 +1081,7 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
       "--match-set", stringify(IPSET_OVERLAY), "dst",
       "-j", "MASQUERADE",
       });
+
   AWAIT_FAILED(iptables);
 
   // Hit the agent end-point again.


### PR DESCRIPTION
* Restructured the overlay agent module so that we can expose the `agent::ManagerProcess` in unit-tests.
* Re-wrote the unit-tests to use `agent::ManagerProcess`.
