### PR TITLE
Combined Logrotate logger functionality into journald logger.

### DIFF
--- a/journald/journald.cpp
+++ b/journald/journald.cpp
@@ -133,7 +133,7 @@ public:
           return Nothing();
         }
 
-        if (flags.destination_type == "logrotate" ||
+        if (flags.destination_type == "journald" ||
             flags.destination_type == "journald+logrotate") {
           // Write the bytes to journald.
           Try<Nothing> result = write_journald(readSize);
@@ -143,7 +143,7 @@ public:
           }
         }
 
-        if (flags.destination_type == "journald" ||
+        if (flags.destination_type == "logrotate" ||
             flags.destination_type == "journald+logrotate") {
           // Write the bytes to sandbox, with log rotation.
           Try<Nothing> result = write_logrotate(readSize);

--- a/journald/journald.cpp
+++ b/journald/journald.cpp
@@ -7,6 +7,7 @@
 
 #include <process/dispatch.hpp>
 #include <process/future.hpp>
+#include <process/id.hpp>
 #include <process/io.hpp>
 #include <process/process.hpp>
 
@@ -17,6 +18,8 @@
 #include <stout/try.hpp>
 
 #include <stout/os/pagesize.hpp>
+#include <stout/os/shell.hpp>
+#include <stout/os/su.hpp>
 
 #include "journald.hpp"
 
@@ -29,7 +32,8 @@ class JournaldLoggerProcess : public Process<JournaldLoggerProcess>
 {
 public:
   JournaldLoggerProcess(const Flags& _flags)
-    : flags(_flags)
+    : ProcessBase(process::ID::generate("journald-logger")),
+      flags(_flags)
   {
     // Prepare a buffer for reading from the `incoming` pipe.
     length = os::pagesize();
@@ -54,6 +58,10 @@ public:
       delete[] entries;
       entries = NULL;
     }
+
+    if (leading.isSome()) {
+      os::close(leading.get());
+    }
   }
 
   // Prepares and starts the loop which reads from stdin and writes to journald.
@@ -73,6 +81,27 @@ public:
       entries[i].iov_len = entry.length();
       entries[i].iov_base = new char[entry.length() + 1];
       std::strcpy((char*) entries[i].iov_base, entry.c_str());
+    }
+
+    if (flags.destination_type != "journald") {
+      // Populate the `logrotate` configuration file.
+      // See `Flags::logrotate_options` for the format.
+      //
+      // NOTE: We specify a size of `--max_size - length` because `logrotate`
+      // has slightly different size semantics.  `logrotate` will rotate when the
+      // max size is *exceeded*.  We rotate to keep files *under* the max size.
+      const std::string config =
+        "\"" + flags.log_filename.get() + "\" {\n" +
+        flags.logrotate_options.getOrElse("") + "\n" +
+        "size " + stringify(flags.max_size.bytes() - length) + "\n" +
+        "}";
+
+      Try<Nothing> result = os::write(
+          flags.log_filename.get() + CONF_SUFFIX, config);
+
+      if (result.isError()) {
+        return Failure("Failed to write configuration file: " + result.error());
+      }
     }
 
     // NOTE: This is a prerequisuite for `io::read`.
@@ -100,11 +129,22 @@ public:
           return Nothing();
         }
 
-        // Write the bytes to journald.
-        Try<Nothing> result = write(readSize);
-        if (result.isError()) {
-          promise.fail("Failed to write: " + result.error());
-          return Nothing();
+        if (flags.destination_type != "sandbox") {
+          // Write the bytes to journald.
+          Try<Nothing> result = write_journald(readSize);
+          if (result.isError()) {
+            promise.fail("Failed to write: " + result.error());
+            return Nothing();
+          }
+        }
+
+        if (flags.destination_type != "journald") {
+          // Write the bytes to sandbox, with log rotation.
+          Try<Nothing> result = write_logrotate(readSize);
+          if (result.isError()) {
+            promise.fail("Failed to write: " + result.error());
+            return Nothing();
+          }
         }
 
         // Use `dispatch` to limit the size of the call stack.
@@ -116,7 +156,7 @@ public:
 
   // Writes the buffer from stdin to the journald.
   // Any `flags.labels` will be prepended to each line.
-  Try<Nothing> write(size_t readSize)
+  Try<Nothing> write_journald(size_t readSize)
   {
     // We may be reading more than one log line at once,
     // but we need to add labels for each line.
@@ -140,12 +180,83 @@ public:
     return Nothing();
   }
 
+
+  // Writes the buffer from stdin to the leading log file.
+  // When the number of written bytes exceeds `--max_size`, the leading
+  // log file is rotated.  When the number of log files exceed `--max_files`,
+  // the oldest log file is deleted.
+  Try<Nothing> write_logrotate(size_t readSize)
+  {
+    // Rotate the log file if it will grow beyond the `--max_size`.
+    if (bytesWritten + readSize > flags.max_size.bytes()) {
+      rotate();
+    }
+
+    // If the leading log file is not open, open it.
+    // NOTE: We open the file in append-mode as `logrotate` may sometimes fail.
+    if (leading.isNone()) {
+      Try<int> open = os::open(
+          flags.log_filename.get(),
+          O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC,
+          S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+      if (open.isError()) {
+        return Error(
+            "Failed to open '" + flags.log_filename.get() +
+            "': " + open.error());
+      }
+
+      leading = open.get();
+    }
+
+    // Write from stdin to `leading`.
+    // NOTE: We do not exit on error here since we are prioritizing
+    // clearing the STDIN pipe (which would otherwise potentially block
+    // the container on write) over log fidelity.
+    Try<Nothing> result =
+      os::write(leading.get(), std::string(buffer, readSize));
+
+    if (result.isError()) {
+      std::cerr << "Failed to write: " << result.error() << std::endl;
+    }
+
+    bytesWritten += readSize;
+
+    return Nothing();
+  }
+
+  // Calls `logrotate` on the leading log file and resets the `bytesWritten`.
+  void rotate()
+  {
+    if (leading.isSome()) {
+      os::close(leading.get());
+      leading = None();
+    }
+
+    // Call `logrotate` to move around the files.
+    // NOTE: If `logrotate` fails for whatever reason, we will ignore
+    // the error and continue logging.  In case the leading log file
+    // is not renamed, we will continue appending to the existing
+    // leading log file.
+    os::shell(
+        flags.logrotate_path +
+        " --state \"" + flags.log_filename.get() + STATE_SUFFIX + "\" \"" +
+        flags.log_filename.get() + CONF_SUFFIX + "\"");
+
+    // Reset the number of bytes written.
+    bytesWritten = 0;
+  }
+
 private:
   Flags flags;
 
   // For reading from stdin.
   char* buffer;
   size_t length;
+
+  // For writing and rotating the leading log file.
+  Option<int> leading;
+  size_t bytesWritten;
 
   // Used as arguments for `sd_journal_sendv`.
   // This contains one more entry than the number of `--labels`.
@@ -174,6 +285,16 @@ int main(int argc, char** argv)
   // Log any flag warnings.
   foreach (const flags::Warning& warning, load->warnings) {
     LOG(WARNING) << warning.message;
+  }
+
+  // If the `--user` flag is set, change the UID of this process to that user.
+  if (flags.user.isSome()) {
+    Try<Nothing> result = os::su(flags.user.get());
+
+    if (result.isError()) {
+      EXIT(EXIT_FAILURE)
+        << ErrnoError("Failed to switch user for journald logger").message;
+    }
   }
 
   // Asynchronously control the flow and size of logs.

--- a/journald/journald.cpp
+++ b/journald/journald.cpp
@@ -85,7 +85,7 @@ public:
     }
 
     if (flags.destination_type == "logrotate" ||
-        flags.destination_type == "both") {
+        flags.destination_type == "journald+logrotate") {
       // Populate the `logrotate` configuration file.
       // See `Flags::logrotate_options` for the format.
       //
@@ -133,8 +133,8 @@ public:
           return Nothing();
         }
 
-        if (flags.destination_type == "sandbox" ||
-            flags.destination_type == "both") {
+        if (flags.destination_type == "logrotate" ||
+            flags.destination_type == "journald+logrotate") {
           // Write the bytes to journald.
           Try<Nothing> result = write_journald(readSize);
           if (result.isError()) {
@@ -144,7 +144,7 @@ public:
         }
 
         if (flags.destination_type == "journald" ||
-            flags.destination_type == "both") {
+            flags.destination_type == "journald+logrotate") {
           // Write the bytes to sandbox, with log rotation.
           Try<Nothing> result = write_logrotate(readSize);
           if (result.isError()) {

--- a/journald/journald.hpp
+++ b/journald/journald.hpp
@@ -13,12 +13,17 @@
 #include <stout/option.hpp>
 #include <stout/protobuf.hpp>
 
+#include <stout/os/pagesize.hpp>
+#include <stout/os/shell.hpp>
+
 
 namespace mesos {
 namespace journald {
 namespace logger {
 
 const std::string NAME = "mesos-journald-logger";
+const std::string CONF_SUFFIX = ".logrotate.conf";
+const std::string STATE_SUFFIX = ".logrotate.state";
 
 struct Flags : public virtual flags::FlagsBase
 {
@@ -31,6 +36,19 @@ struct Flags : public virtual flags::FlagsBase
       "Each line (delineated by newline) of STDIN is labeled with --labels\n"
       "before it is written to journald.  See '--labels'."
       "\n");
+
+    add(&Flags::destination_type,
+        "destination_type",
+        "Determines where logs should be piped.\n"
+        "Valid destinations include: 'journald', 'sandbox', or 'both'.",
+        "journald",
+        [](const std::string& value) -> Option<Error> {
+          if (value != "journald" && value != "sandbox" && value != "both") {
+            return Error("Invalid destination type: " + value);
+          }
+
+          return None();
+        });
 
     add(&Flags::labels,
         "labels",
@@ -65,12 +83,86 @@ struct Flags : public virtual flags::FlagsBase
           parsed_labels = _labels.get();
           return None();
         });
+
+    add(&Flags::max_size,
+        "max_size",
+        "Maximum size, in bytes, of a single log file.\n"
+        "Defaults to 10 MB.  Must be at least 1 (memory) page.",
+        Megabytes(10),
+        [](const Bytes& value) -> Option<Error> {
+          if (value.bytes() < os::pagesize()) {
+            return Error(
+                "Expected --max_size of at least " +
+                stringify(os::pagesize()) + " bytes");
+          }
+          return None();
+        });
+
+    add(&Flags::logrotate_options,
+        "logrotate_options",
+        "Additional config options to pass into 'logrotate'.\n"
+        "This string will be inserted into a 'logrotate' configuration file.\n"
+        "i.e.\n"
+        "  /path/to/<log_filename> {\n"
+        "    <logrotate_options>\n"
+        "    size <max_size>\n"
+        "  }\n"
+        "NOTE: The 'size' option will be overriden by this command.");
+
+    add(&Flags::log_filename,
+        "log_filename",
+        "Absolute path to the leading log file.\n"
+        "NOTE: This command will also create two files by appending\n"
+        "'" + CONF_SUFFIX + "' and '" + STATE_SUFFIX + "' to the end of\n"
+        "'--log_filename'.  These files are used by 'logrotate'.",
+        [](const Option<std::string>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("Missing required option --log_filename");
+          }
+
+          if (!path::absolute(value.get())) {
+            return Error("Expected --log_filename to be an absolute path");
+          }
+
+          return None();
+        });
+
+    add(&Flags::logrotate_path,
+        "logrotate_path",
+        "If specified, this command will use the specified\n"
+        "'logrotate' instead of the system's 'logrotate'.",
+        "logrotate",
+        [](const std::string& value) -> Option<Error> {
+          // Check if `logrotate` exists via the help command.
+          // TODO(josephw): Consider a more comprehensive check.
+          Try<std::string> helpCommand =
+            os::shell(value + " --help > /dev/null");
+
+          if (helpCommand.isError()) {
+            return Error(
+                "Failed to check logrotate: " + helpCommand.error());
+          }
+
+          return None();
+        });
+
+    add(&Flags::user,
+        "user",
+        "The user this command should run as.");
   }
+
+  std::string destination_type;
 
   Option<std::string> labels;
 
   // Values populated during validation.
   Labels parsed_labels;
+
+  Bytes max_size;
+  Option<std::string> logrotate_options;
+  Option<std::string> log_filename;
+  std::string logrotate_path;
+  Option<std::string> user;
 };
 
 } // namespace logger {

--- a/journald/journald.hpp
+++ b/journald/journald.hpp
@@ -40,10 +40,13 @@ struct Flags : public virtual flags::FlagsBase
     add(&Flags::destination_type,
         "destination_type",
         "Determines where logs should be piped.\n"
-        "Valid destinations include: 'journald', 'logrotate', or 'both'.",
+        "Valid destinations include: 'journald', 'logrotate',\n"
+        "or 'journald+logrotate'.",
         "journald",
         [](const std::string& value) -> Option<Error> {
-          if (value != "journald" && value != "logrotate" && value != "both") {
+          if (value != "journald" &&
+              value != "logrotate" &&
+              value != "journald+logrotate") {
             return Error("Invalid destination type: " + value);
           }
 

--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -93,17 +93,17 @@ public:
     environment["LIBPROCESS_NUM_WORKER_THREADS"] =
       stringify(flags.libprocess_num_worker_threads);
 
-    // Copy the global rotation flags.
+    // Copy the global logger flags.
     // These will act as the defaults in case the executor environment
     // overrides a subset of them.
-    LoggerFlags overridenFlags;
-    overridenFlags.destination_type = flags.destination_type;
-    overridenFlags.max_stdout_size = flags.max_stdout_size;
-    overridenFlags.logrotate_stdout_options = flags.logrotate_stdout_options;
-    overridenFlags.max_stderr_size = flags.max_stderr_size;
-    overridenFlags.logrotate_stderr_options = flags.logrotate_stderr_options;
+    LoggerFlags overriddenFlags;
+    overriddenFlags.destination_type = flags.destination_type;
+    overriddenFlags.logrotate_max_stdout_size = flags.logrotate_max_stdout_size;
+    overriddenFlags.logrotate_stdout_options = flags.logrotate_stdout_options;
+    overriddenFlags.logrotate_max_stderr_size = flags.logrotate_max_stderr_size;
+    overriddenFlags.logrotate_stderr_options = flags.logrotate_stderr_options;
 
-    // Check for overrides of the rotation settings in the
+    // Check for overrides of the logger settings in the
     // `ExecutorInfo`s environment variables.
     if (executorInfo.has_command() &&
         executorInfo.command().has_environment()) {
@@ -123,7 +123,7 @@ public:
       }
 
       // We will error out if there are unknown flags with the same prefix.
-      Try<flags::Warnings> load = overridenFlags.load(executorEnvironment);
+      Try<flags::Warnings> load = overriddenFlags.load(executorEnvironment);
 
       if (load.isError()) {
         return Failure(
@@ -229,13 +229,13 @@ public:
     labels.add_labels()->CopyFrom(label);
 
     mesos::journald::logger::Flags outFlags;
-    outFlags.destination_type = overridenFlags.destination_type;
+    outFlags.destination_type = overriddenFlags.destination_type;
 
-    outFlags.labels = stringify(JSON::protobuf(labels));
+    outFlags.journald_labels = stringify(JSON::protobuf(labels));
 
-    outFlags.max_size = overridenFlags.max_stdout_size;
-    outFlags.logrotate_options = overridenFlags.logrotate_stdout_options;
-    outFlags.log_filename = path::join(sandboxDirectory, "stdout");
+    outFlags.logrotate_max_size = overriddenFlags.logrotate_max_stdout_size;
+    outFlags.logrotate_options = overriddenFlags.logrotate_stdout_options;
+    outFlags.logrotate_filename = path::join(sandboxDirectory, "stdout");
     outFlags.logrotate_path = flags.logrotate_path;
     outFlags.user = user;
 
@@ -295,13 +295,13 @@ public:
     labels.add_labels()->CopyFrom(label);
 
     mesos::journald::logger::Flags errFlags;
-    errFlags.destination_type = overridenFlags.destination_type;
+    errFlags.destination_type = overriddenFlags.destination_type;
 
-    errFlags.labels = stringify(JSON::protobuf(labels));
+    errFlags.journald_labels = stringify(JSON::protobuf(labels));
 
-    errFlags.max_size = overridenFlags.max_stderr_size;
-    errFlags.logrotate_options = overridenFlags.logrotate_stderr_options;
-    errFlags.log_filename = path::join(sandboxDirectory, "stderr");
+    errFlags.logrotate_max_size = overriddenFlags.logrotate_max_stderr_size;
+    errFlags.logrotate_options = overriddenFlags.logrotate_stderr_options;
+    errFlags.logrotate_filename = path::join(sandboxDirectory, "stderr");
     errFlags.logrotate_path = flags.logrotate_path;
     errFlags.user = user;
 

--- a/journald/lib_journald.hpp
+++ b/journald/lib_journald.hpp
@@ -30,10 +30,13 @@ struct LoggerFlags : public virtual flags::FlagsBase
     add(&LoggerFlags::destination_type,
         "destination_type",
         "Determines where logs should be piped.\n"
-        "Valid destinations include: 'journald', 'logrotate', or 'both'.",
+        "Valid destinations include: 'journald', 'logrotate',\n"
+        "or 'journald+logrotate'.",
         "journald",
         [](const std::string& value) -> Option<Error> {
-          if (value != "journald" && value != "logrotate" && value != "both") {
+          if (value != "journald" &&
+              value != "logrotate" &&
+              value != "journald+logrotate") {
             return Error("Invalid destination type: " + value);
           }
 

--- a/journald/lib_journald.hpp
+++ b/journald/lib_journald.hpp
@@ -30,18 +30,18 @@ struct LoggerFlags : public virtual flags::FlagsBase
     add(&LoggerFlags::destination_type,
         "destination_type",
         "Determines where logs should be piped.\n"
-        "Valid destinations include: 'journald', 'sandbox', or 'both'.",
+        "Valid destinations include: 'journald', 'logrotate', or 'both'.",
         "journald",
         [](const std::string& value) -> Option<Error> {
-          if (value != "journald" && value != "sandbox" && value != "both") {
+          if (value != "journald" && value != "logrotate" && value != "both") {
             return Error("Invalid destination type: " + value);
           }
 
           return None();
         });
 
-    add(&LoggerFlags::max_stdout_size,
-        "max_stdout_size",
+    add(&LoggerFlags::logrotate_max_stdout_size,
+        "logrotate_max_stdout_size",
         "Maximum size, in bytes, of a single stdout log file.\n"
         "Defaults to 10 MB.  Must be at least 1 (memory) page.",
         Megabytes(10),
@@ -54,12 +54,12 @@ struct LoggerFlags : public virtual flags::FlagsBase
         "i.e.\n"
         "  /path/to/stdout {\n"
         "    <logrotate_stdout_options>\n"
-        "    size <max_stdout_size>\n"
+        "    size <logrotate_max_stdout_size>\n"
         "  }\n"
-        "NOTE: The 'size' option will be overriden by this module.");
+        "NOTE: The 'size' option will be overridden by this module.");
 
-    add(&LoggerFlags::max_stderr_size,
-        "max_stderr_size",
+    add(&LoggerFlags::logrotate_max_stderr_size,
+        "logrotate_max_stderr_size",
         "Maximum size, in bytes, of a single stderr log file.\n"
         "Defaults to 10 MB.  Must be at least 1 (memory) page.",
         Megabytes(10),
@@ -72,9 +72,9 @@ struct LoggerFlags : public virtual flags::FlagsBase
         "i.e.\n"
         "  /path/to/stderr {\n"
         "    <logrotate_stderr_options>\n"
-        "    size <max_stderr_size>\n"
+        "    size <logrotate_max_stderr_size>\n"
         "  }\n"
-        "NOTE: The 'size' option will be overriden by this module.");
+        "NOTE: The 'size' option will be overridden by this module.");
   }
 
   static Option<Error> validateSize(const Bytes& value)
@@ -90,10 +90,10 @@ struct LoggerFlags : public virtual flags::FlagsBase
 
   std::string destination_type;
 
-  Bytes max_stdout_size;
+  Bytes logrotate_max_stdout_size;
   Option<std::string> logrotate_stdout_options;
 
-  Bytes max_stderr_size;
+  Bytes logrotate_max_stderr_size;
   Option<std::string> logrotate_stderr_options;
 };
 
@@ -105,15 +105,15 @@ struct Flags : public virtual LoggerFlags
     add(&Flags::environment_variable_prefix,
         "environment_variable_prefix",
         "Prefix for environment variables meant to modify the behavior of\n"
-        "the logrotate logger for the specific executor being launched.\n"
-        "The logger will look for four prefixed environment variables in the\n"
+        "the container logger for the specific executor being launched.\n"
+        "The logger will look for the prefixed environment variables in the\n"
         "'ExecutorInfo's 'CommandInfo's 'Environment':\n"
         "  * DESTINATION_TYPE\n"
-        "  * MAX_STDOUT_SIZE\n"
+        "  * LOGROTATE_MAX_STDOUT_SIZE\n"
         "  * LOGROTATE_STDOUT_OPTIONS\n"
-        "  * MAX_STDERR_SIZE\n"
+        "  * LOGROTATE_MAX_STDERR_SIZE\n"
         "  * LOGROTATE_STDERR_OPTIONS\n"
-        "If present, these variables will overwrite the global values set\n"
+        "If present, these variables will override the global values set\n"
         "via module parameters.",
         "CONTAINER_LOGGER_");
 
@@ -179,18 +179,21 @@ struct Flags : public virtual LoggerFlags
 };
 
 
-// The `JournaldContainerLogger` is a ContainerLogger module that pipes
-// the stdout/stderr of a container to journald. The module assumes the
-// stdout/stderr outputs generic single line logs (i.e. delineated by
-// newlines) and adds identifying labels to each log line; such
-// as the FrameworkID, ExecutorID, ContainerID, and labels inside
-// ExecutorInfo.
-//
 // For backwards compatibility, this module provides three modes:
 //   * Log to journald.
 //   * Log to journald and the sandbox, with log rotation.
 //   * Log to sandbox, with log rotation.
-// Logging to sandbox is equivalent to using the `LogrotateContainerLogger`.
+//
+// When logging to journald, the `JournaldContainerLogger` is a
+// ContainerLogger module that pipes the stdout/stderr of a container
+// to journald. The module assumes the stdout/stderr outputs generic
+// single line logs (i.e. delineated by newlines) and adds identifying
+// labels to each log line; such as the FrameworkID, ExecutorID,
+// ContainerID, and labels inside ExecutorInfo.
+//
+// Logging to sandbox is approximately equivalent to using the
+// `LogrotateContainerLogger`, packaged with vanilla Mesos.
+// See `Flags` above.
 class JournaldContainerLogger : public mesos::slave::ContainerLogger
 {
 public:

--- a/journald/modules.json.in
+++ b/journald/modules.json.in
@@ -12,6 +12,9 @@
             }, {
               "key": "libprocess_num_worker_threads",
               "value": "2"
+            }, {
+              "key": "destination_type",
+              "value": "both"
             }
           ]
         }

--- a/journald/modules.json.in
+++ b/journald/modules.json.in
@@ -14,7 +14,7 @@
               "value": "2"
             }, {
               "key": "destination_type",
-              "value": "both"
+              "value": "journald+logrotate"
             }
           ]
         }

--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -258,6 +258,27 @@ TEST_F(JournaldLoggerTest, ROOT_LogToJournald)
 
   AWAIT_READY(executorQuery);
   ASSERT_TRUE(strings::contains(executorQuery.get(), specialString));
+
+  // Check that the sandbox was written to as well.
+  string sandboxDirectory = path::join(
+      flags.work_dir,
+      "slaves",
+      offers.get()[0].slave_id().value(),
+      "frameworks",
+      frameworkId.get().value(),
+      "executors",
+      statusRunning->executor_id().value(),
+      "runs",
+      "latest");
+
+  ASSERT_TRUE(os::exists(sandboxDirectory));
+
+  string stdoutPath = path::join(sandboxDirectory, "stdout");
+  ASSERT_TRUE(os::exists(stdoutPath));
+
+  Result<string> stdout = os::read(stdoutPath);
+  ASSERT_SOME(stdout);
+  EXPECT_TRUE(strings::contains(stdout.get(), specialString));
 }
 
 


### PR DESCRIPTION
This provides a backwards compatibility mode for the container logger.
In case the sandbox logs are still necessary, this adds a "destination_type" option which can pipe logs to both journald and the sandbox.