### PR TITLE
Logsink: Removed read permissions on log file for "other users".

### DIFF
--- a/logsink/logsink.cpp
+++ b/logsink/logsink.cpp
@@ -40,7 +40,7 @@ FileSink::FileSink(const Flags& _flags) : flags(_flags)
   Try<int> open = os::open(
       flags.output_file,
       O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC,
-      S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+      S_IRUSR | S_IWUSR | S_IRGRP);
   CHECK_SOME(open);
 
   logFd = open.get();


### PR DESCRIPTION
This sets the permissions on the log file generated by the logsink
module to: Read/Write for the owner of the file and Read for the group.

This does not change permissions on existing files.  But newly created log files will have the updated permissions.
JIRA: https://jira.mesosphere.com/browse/DCOS-12261