### PR TITLE
Fixed compilation errors for `make check`.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,9 +5,10 @@ if SOURCE_PROVIDED
 # Render path to Mesos bundled gmock.
 BUNDLE_SUBDIR = 3rdparty
 
+GOOGLETEST = $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/googletest-release-$(GOOGLETEST_VERSION)
 include $(MESOS_ROOT)/$(BUNDLE_SUBDIR)/versions.am
-GMOCK = $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/gmock-$(GMOCK_VERSION)
-GTEST = $(GMOCK)/gtest
+GMOCK = $(GOOGLETEST)/googlemock
+GTEST = $(GOOGLETEST)/googletest
 ZOOKEEPER = $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/zookeeper-$(ZOOKEEPER_VERSION)/src/c
 endif
 


### PR DESCRIPTION
The `GMOCK_VERSION` has been deprecated in Mesos so needed to the tests
to use `GOOGLETEST_VERSION` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos-mesos-modules/15)
<!-- Reviewable:end -->
