### PR TITLE
Fix segfault in tests and potential badness in general.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,9 @@ GOOGLETEST = $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/googletest-release-$(GOOGLETEST
 include $(MESOS_ROOT)/$(BUNDLE_SUBDIR)/versions.am
 GMOCK = $(GOOGLETEST)/googlemock
 GTEST = $(GOOGLETEST)/googletest
+
 ZOOKEEPER = $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/zookeeper-$(ZOOKEEPER_VERSION)/src/c
+NVML = $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/nvml-$(NVML_VERSION)
 endif
 
 # We want to install modules in mesos directory.
@@ -147,6 +149,7 @@ libmesos_tests_la_CPPFLAGS =				\
   -I$(MESOS_BUILD_DIR)/include/mesos			\
   -I$(ZOOKEEPER)/include				\
   -I$(ZOOKEEPER)/generated				\
+  -I$(NVML)						\
   -isystem $(GMOCK)/include				\
   -I$(GTEST)/include					\
   -DMODULES_BUILD_DIR=\"$(abs_top_builddir)\"		\

--- a/configure.ac
+++ b/configure.ac
@@ -320,7 +320,7 @@ AC_CHECK_HEADER([google/protobuf/message.h],
                 [AC_MSG_ERROR([google protobuf is not installed.])])
 
 AC_CHECK_HEADERS([openssl/ssl.h],
-                 [],
+                 [MESOS_CPPFLAGS+=" -DUSE_SSL_SOCKET"],
                  [AC_MSG_ERROR([cannot find libssl headers])])
 
 AC_CHECK_HEADERS([boost/lexical_cast.hpp boost/functional/hash.hpp],


### PR DESCRIPTION
DC/OS compiles Mesos with Libevent and SSL enabled, which means that `-DUSE_SSL_SOCKET` is defined during compilation time across all files.  This definition was missing in this modules repo, which leads to a subtle abort/segfault during tests:

```
[ RUN      ] DockerRemoveTest.VerifyRemoveDockerCfgHook
ABORT: (../../3rdparty/stout/include/stout/flags/flags.hpp:433): Attempted to add flag 'hostname' with incompatible type
*** Aborted at 1499293280 (unix time) try "date -d @1499293280" if you are using GNU date ***
PC: @     0x2b806a3607ef (unknown)
*** SIGABRT (@0x3e80000636d) received by PID 25453 (TID 0x2b8061116280) from PID 25453; stack trace: ***
    @     0x556f73d34f0c _Abort()
    @     0x2b8066c7fe05 _ZN5flags9FlagsBase3addIN5mesos8internal5slave5FlagsENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEZNS0_3addIS5_SB_EEvMT_6OptionIT0_ERKNS_4NameERKSB_EUlRKSE_ISB_EE_EEvSH_SK_RKSE_ISI_ESM_T1_
    @     0x2b8066c7c953 flags::FlagsBase::add<>()
    @     0x2b8066c72336 mesos::internal::slave::Flags::Flags()
    @     0x2b8069880e92 mesos::internal::tests::MesosTest::CreateSlaveFlags()
    @     0x556f73d2fb88 mesos::dockerRemove::tests::DockerRemoveTest_VerifyRemoveDockerCfgHook_Test::TestBody()
```

This error occurs when calling the rather innocent looking constructor for the Mesos Agent flags: `mesos::internal::slave::Flags::Flags()`.  Under the hood, `Flags` is a super-class of the stout `FlagsBase` template class.  Each time we go to add a new field to the `Flags`, the `FlagsBase` attempts to up-cast (via `dynamic_cast`) from `FlagsBase` to the templatized `Flags` type.  `dynamic_cast` will return `nullptr` if the cast fails, hence the segfaults.

The reason why the up-cast was failing is because the agent flags include an `#ifdef USE_SSL_SOCKET`, which means that the `Flags` with and without `USE_SSL_SOCKET` are actually different classes.  This meant the module tests were attempting to construct non-SSL agent flags, while linking to SSL agent flags.