### PR TITLE
Fixed CHECK failure for one case with nested containers.

### DIFF
--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -163,10 +163,16 @@ public:
 
     // NOTE: This field is required by the master/agent, but the protobuf
     // is optional for backwards compatibility.
-    CHECK(executorInfo.has_framework_id());
-    label.set_key("FRAMEWORK_ID");
-    label.set_value(executorInfo.framework_id().value());
-    labels.add_labels()->CopyFrom(label);
+    //
+    // NOTE: It is possible for the ExecutorInfo object to be blank if
+    // a nested container is launched after restarting the Mesos agent.
+    // This is because the agent does not need to keep the ExecutorInfo
+    // checkpointed after it has already launched the executor.
+    if (executorInfo.has_framework_id()) {
+      label.set_key("FRAMEWORK_ID");
+      label.set_value(executorInfo.framework_id().value());
+      labels.add_labels()->CopyFrom(label);
+    }
 
     label.set_key("EXECUTOR_ID");
     label.set_value(executorInfo.executor_id().value());


### PR DESCRIPTION
If a nested container is launched on a parent container after
restarting the agent (the parent container is launched prior to
restart), then the ExecutorInfo passed into the ContainerLogger
may be blank.  This means that fields that are normally required
such as FrameworkID and ExecutorID will be blank.

This includes one test which:
1. Launches a parent container (prints then sleeps)
2. Emulates an agent failover
3. Launches a nested container (prints then exits)
4. Checks that filtering by `AGENT_ID` shows parent+child messages
5. Checks that filtering by `FRAMEWORK_ID` only shows the parent message
```
sudo ./test-journald --gtest_filter="*ROOT_CGROUPS_LaunchThenRecoverThenLaunchNested" --gtest_repeat=100 --gtest_break_on_failure
```