### PR TITLE
Create testcase for Mesos master failover with DC/OS overlay modules

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -541,6 +541,7 @@ Future<http::Response> ManagerProcess::overlay(const http::Request& request)
 {
   AgentInfo agent;
   agent.set_ip(stringify(self().address.ip));
+  agent.set_configuration_attempts(configAttempts);
 
   foreachvalue (const AgentOverlayInfo& overlay, overlays) {
     agent.add_overlays()->CopyFrom(overlay);

--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -421,6 +421,8 @@ void ManagerProcess::agentRegisteredAcknowledgement(const UPID& from)
 
   configAttempts++;
 
+  link(from);
+
   if (configAttempts > maxConfigAttempts) {
     LOG(ERROR) << "Could not configure some overlay networks after "
                << configAttempts

--- a/overlay/agent.hpp
+++ b/overlay/agent.hpp
@@ -21,7 +21,9 @@ class ManagerProcess : public ProtobufProcess<ManagerProcess>
 {
 public:
   static Try<process::Owned<ManagerProcess>> create(
-      const overlay::internal::AgentConfig& agentConfig);
+      const overlay::internal::AgentConfig& agentConfig,
+      Option<process::Owned<master::detector::MasterDetector>>
+        detector = None());
 
   process::Future<Nothing> ready();
 
@@ -80,6 +82,9 @@ private:
       const uint32_t _maxConfigAttempts,
       process::Owned<master::detector::MasterDetector> _detector);
 
+  static Try<process::Owned<master::detector::MasterDetector>> createDetector(
+      const internal::AgentConfig& agentConfig);
+
   const std::string cniDir;
 
   const overlay::internal::AgentNetworkConfig networkConfig;
@@ -104,7 +109,9 @@ class Manager : public Anonymous
 {
 public:
   static Try<Manager*> create(
-      const overlay::internal::AgentConfig& agentConfig);
+      const overlay::internal::AgentConfig& agentConfig,
+      Option<process::Owned<master::detector::MasterDetector>>
+        detector = None());
 
   virtual ~Manager();
 

--- a/overlay/overlay.proto
+++ b/overlay/overlay.proto
@@ -96,6 +96,10 @@ message AgentInfo {
 
   // The overlay networks that exist on this agent.
   repeated AgentOverlayInfo overlays = 2;
+
+  // Number of configuration attempts. For more information
+  // please see max_configuration_attempts in AgentConfig.
+  optional uint32 configuration_attempts = 3;
 }
 
 


### PR DESCRIPTION
Currently, if there are multiple configuraton attempt failures for the overlay module running on the agent, when registered with the overlay module in the Master it leads to the overlay modules actor just giving up on the registration.

We need to test that the number of configuration attemtps are reset when master failover happens, i.e., if a master failover happens and number of config attempts is less than the number of attempts supported by the overlay module the number of config attempts should be reset and the overlay module should continue attempting to register.

JIRA: https://jira.mesosphere.com/browse/DCOS_OSS-728