### PR TITLE
Introduce timeouts for calls to docker deamon in DC/OS overlay module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -228,9 +228,25 @@ test_overlay_LDADD =					\
   $(MESOS_BUILD_DIR)/src/.libs/libmesos.la		\
   libmesos_tests.la					\
   libmesos_network_overlay.la
+
+# Test (make check) binary for the common functions
+check_PROGRAMS += test-common
+
+test_common_SOURCES =					\
+  tests/common_tests.cpp
+
+test_common_CPPFLAGS =					\
+  $(libmesos_tests_la_CPPFLAGS)
+
+test_common_LDADD =					\
+  $(MESOS_LDFLAGS)					\
+  $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/.libs/libgmock.la	\
+  $(MESOS_BUILD_DIR)/src/.libs/libmesos.la		\
+  libmesos_tests.la
 endif
 
 check-local: $(check_PROGRAMS)
+	./test-common --verbose
 	./test-dockercfg
 	./test-journald --verbose
 	./test-logsink --verbose

--- a/common/shell.hpp
+++ b/common/shell.hpp
@@ -8,68 +8,11 @@
 #include <process/future.hpp>
 #include <process/subprocess.hpp>
 
+#include <stout/os/shell.hpp>
+
 namespace mesos {
 namespace modules {
 namespace common {
-
-// Run `command` as a shell script. This is useful when wanting to
-// chain shell commands.
-inline process::Future<std::string> runScriptCommand(
-    const std::string& command)
-{
-  Try<process::Subprocess> s = process::subprocess(
-      command,
-      process::Subprocess::PATH("/dev/null"),
-      process::Subprocess::PIPE(),
-      process::Subprocess::PIPE());
-
-  if (s.isError()) {
-    return process::Failure(
-        "Unable to execute '" + command + "': " + s.error());
-  }
-
-  return await(
-      s->status(),
-      process::io::read(s->out().get()),
-      process::io::read(s->err().get()))
-    .then([command](
-          const std::tuple<process::Future<Option<int>>,
-          process::Future<std::string>,
-          process::Future<std::string>>& t) -> process::Future<std::string> {
-        process::Future<Option<int>> status = std::get<0>(t);
-        if (!status.isReady()) {
-          return process::Failure(
-            "Failed to get the exit status of '" + command +"': " +
-            (status.isFailed() ? status.failure() : "discarded"));
-        }
-
-        if (status->isNone()) {
-          return process::Failure("Failed to reap the subprocess");
-        }
-
-        process::Future<std::string> out = std::get<1>(t);
-        if (!out.isReady()) {
-          return process::Failure(
-            "Failed to read stderr from the subprocess: " +
-            (out.isFailed() ? out.failure() : "discarded"));
-        }
-
-        process::Future<std::string> err = std::get<2>(t);
-        if (!err.isReady()) {
-          return process::Failure(
-              "Failed to read stderr from the subprocess: " +
-              (err.isFailed() ? err.failure() : "discarded"));
-        }
-
-        if (status.get() != 0) {
-          return process::Failure(
-              "Failed to execute '" + command + "': " + err.get());
-        }
-
-        return out.get();
-    });
-};
-
 
 // Exec's a command.
 inline process::Future<std::string> runCommand(
@@ -84,7 +27,8 @@ inline process::Future<std::string> runCommand(
       process::Subprocess::PIPE());
 
   if (s.isError()) {
-    return process::Failure("Unable to execute '" + command + "': " + s.error());
+    return process::Failure(
+      "Unable to execute '" + command + "': " + s.error());
   }
 
   return await(
@@ -127,6 +71,17 @@ inline process::Future<std::string> runCommand(
 
         return out.get();
     });
+};
+
+
+// Run `command` as a shell script. This is useful when wanting to
+// chain shell commands.
+inline process::Future<std::string> runScriptCommand(
+    const std::string& command)
+{
+  std::vector<std::string> argv = {os::Shell::arg0, os::Shell::arg1, command};
+
+  return runCommand(os::Shell::name, argv);
 };
 
 } // namespace common {

--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -196,7 +196,10 @@ Try<Owned<ManagerProcess>> ManagerProcess::create(
           "Unable to create `ipset` command: " + ipsetCommand.error());
     }
 
-    Future<string> ipset = runScriptCommand(ipsetCommand.get());
+    Duration timeout = Milliseconds(networkConfig.command_timeout());
+    Future<string> ipset = runScriptCommand(
+        ipsetCommand.get(),
+        timeout);
 
     ipset.await();
 
@@ -660,7 +663,8 @@ Future<Nothing> ManagerProcess::_configure(
     // `_updateAgentOverlays`, which might not be set if this race
     // were to occur, even though the overlay configuration went
     // through fine.
-    return runScriptCommand(command.get())
+    Duration timeout = Milliseconds(networkConfig.command_timeout());
+    return runScriptCommand(command.get(), timeout)
       .then(defer(self(), overlaySuccess))
       .onFailed(defer(self(), overlayFailure))
       .onDiscarded(defer(self(), lambda::bind(overlayFailure, "discarded")));
@@ -868,7 +872,8 @@ Future<Nothing> ManagerProcess::_configureDockerNetwork(
         dockerCommand.error());
   }
 
-  return runScriptCommand(dockerCommand.get())
+  Duration timeout = Milliseconds(networkConfig.command_timeout());
+  return runScriptCommand(dockerCommand.get(), timeout)
     .then(defer(self(),
           &Self::__configureDockerNetwork,
           name,
@@ -894,7 +899,8 @@ Future<Nothing> ManagerProcess::__configureDockerNetwork(
   const string iptablesCommand = "iptables -D DOCKER-ISOLATION -j RETURN; "
     "iptables -I DOCKER-ISOLATION 1 -j RETURN";
 
-  return runScriptCommand(iptablesCommand)
+  Duration timeout = Milliseconds(networkConfig.command_timeout());
+  return runScriptCommand(iptablesCommand, timeout)
     .then([]() -> Future<Nothing> {
         return Nothing();
         });

--- a/overlay/messages.proto
+++ b/overlay/messages.proto
@@ -58,6 +58,9 @@ message AgentNetworkConfig {
   // however to support GCE we are setting the default MTU value to
   // 1420 bytes.
   optional uint32 overlay_mtu = 4 [default = 1420];
+
+  // Timeout for calls to docker deamon and networking tools, ms
+  optional uint32 command_timeout = 5 [default = 15000];
 }
 
 

--- a/tests/common_tests.cpp
+++ b/tests/common_tests.cpp
@@ -1,0 +1,55 @@
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+
+#include <stout/strings.hpp>
+
+#include "tests/mesos.hpp"
+
+#include "common/shell.hpp"
+
+using namespace std;
+using namespace strings;
+using namespace process;
+using namespace mesos::internal::tests;
+using namespace mesos::modules::common;
+
+namespace mesos {
+namespace common {
+namespace tests {
+
+class CommonTest : public MesosTest {
+protected:
+  virtual void SetUp()
+  {
+    MesosTest::SetUp();
+  }
+
+  virtual void TearDown()
+  {
+    MesosTest::TearDown();
+  }
+};
+
+TEST_F(CommonTest, CheckRunScriptCommandBasic)
+{
+  Future<string> r = runScriptCommand("echo -n foobar");
+  AWAIT_READY(r);
+  EXPECT_EQ("foobar", r.get());
+}
+
+TEST_F(CommonTest, CheckRunScriptCommandTimeout)
+{
+  Future<string> r0 = runScriptCommand("sleep 1");
+  AWAIT_READY(r0);
+
+  Future<string> r1 = runScriptCommand("sleep 1", Milliseconds(100));
+  r1.await();
+  CHECK_FAILED(r1);
+  EXPECT_EQ(true, endsWith(r1.failure(), "timeout after 100ms"));
+}
+
+} // namespace tests {
+} // namespace common {
+} // namespace mesos {


### PR DESCRIPTION
The overlay module currently shells out to docker in order to create and inspect docker networks. If the docker daemon hangs, or is unreachable this can end up blocking the overlay agent module. We therefore need to introduce timeouts to calls to the docker daemon and ensure that we handle the failure scenario correctly.

JIRA: https://jira.mesosphere.com/browse/DCOS_OSS-695