### PR TITLE
Add MTU configuration for vtep1024

### DIFF
--- a/overlay/overlay.proto
+++ b/overlay/overlay.proto
@@ -22,6 +22,7 @@ message VxLANInfo {
   required string vtep_ip = 3;
   required string vtep_mac = 4;
   optional string vtep_ip6 = 5;
+  optional uint32 vtep_mtu = 6;
 }
 
 
@@ -131,4 +132,7 @@ message NetworkConfig {
 
   // IPv6 subnet for vtep
   optional string vtep_subnet6 = 4;
+
+  // MTU for vtep
+  optional uint32 vtep_mtu = 5;
 }


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-1529

> DC/OS Config "dcos_overlay_mtu" can not be used for VTEP1024. VTEP1024's MTU is always greater(more than 54 bytes?) than "dcos_overlay_mtu" for vxlan overhead.