### PR TITLE
Adapted to the new logger interface.

### DIFF
--- a/journald/lib_journald.hpp
+++ b/journald/lib_journald.hpp
@@ -225,8 +225,9 @@ public:
   // This is a noop.  The journald container logger has nothing to initialize.
   virtual Try<Nothing> initialize();
 
-  virtual process::Future<mesos::slave::ContainerIO>
-  prepare(const mesos::slave::ContainerConfig& containerConfig);
+  virtual process::Future<mesos::slave::ContainerIO> prepare(
+      const ContainerID& containerId,
+      const mesos::slave::ContainerConfig& containerConfig);
 
 protected:
   Flags flags;


### PR DESCRIPTION
Now the `prepare()` method takes `ContainerID` as a parameter. We no
longer need to calculate the container ID in a hacky way.