### PR TITLE
This patch is to fix upgrade issues from DC/OS 1.10 to 1.11+

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -862,7 +862,7 @@ Future<Nothing> ManagerProcess::_configureDockerNetwork(
     subnet = _subnet.get();
   }
 
-  if (overlay.docker_bridge().has_ip6()) {
+  if (overlay.docker_bridge().has_ip6() && networkConfig.enable_ipv6()) {
     Try<Network> _subnet6 = Network::parse(
         overlay.docker_bridge().ip6(),
         AF_INET6);
@@ -871,6 +871,11 @@ Future<Nothing> ManagerProcess::_configureDockerNetwork(
       return Failure("Failed to parse bridge ipv6: " + _subnet6.error());
     }
     subnet6 = _subnet6.get();
+  }
+
+  if (!subnet.isSome() && !subnet6.isSome()) {
+      // nothing to configure
+      return Nothing();
   }
 
   Try<string> dockerCommand = strings::format(

--- a/overlay/master.cpp
+++ b/overlay/master.cpp
@@ -687,6 +687,18 @@ public:
     }
   }
 
+  BackendInfo getBackendInfo() const
+  {
+    return backend.get();
+  }
+
+  void setBackendInfo(Option<BackendInfo> backendInfo)
+  {
+      if (backendInfo.isSome()) {
+          backend = backendInfo.get();
+      }
+  }
+
   AgentInfo getAgentInfo() const
   {
     AgentInfo info;
@@ -1287,14 +1299,30 @@ protected:
     if (agents.contains(agentIP.get())) {
       LOG(INFO) << "Agent " << pid << " re-registering.";
 
+      Agent* agent = &(agents.at(agentIP.get()));
+      // Check if IPv6 address is added to a vtep interface
+      // and it is not present on the agent vtep
+      BackendInfo backendInfo = agent->getBackendInfo();
+      if (vtep.network6.isSome() &&
+           !backendInfo.vxlan().has_vtep_ip6()) {
+        Try<Network> vtepIP6 = vtep.allocateIP6();
+        if (vtepIP6.isError()) {
+          LOG(ERROR)
+            << "Unable to get VTEP IPv6 for Agent: " << vtepIP6.error()
+            << "Cannot fulfill re-registration for Agent: " << pid;
+          return;
+        }
+
+        backendInfo.mutable_vxlan()->set_vtep_ip6(stringify(vtepIP6.get()));
+        agent->setBackendInfo(backendInfo);
+      }
+
       // Check if any new overlay need to be installed on the
       // agent.
-      if (agents.at(agentIP.get()).addOverlays(
-            overlays,
-            registerMessage.network_config())) {
+      if (agent->addOverlays(overlays, registerMessage.network_config())) {
         // We installed a new overlay on this agent.
         update(Owned<Operation>(
-               new ModifyAgent(agents.at(agentIP.get()).getAgentInfo())))
+               new ModifyAgent(agent->getAgentInfo())))
           .onAny(defer(self(),
                  &ManagerProcess::_registerAgent,
                  pid,
@@ -1590,6 +1618,9 @@ protected:
               << network6.error();
             abort();
           }
+
+          // We should already have this particular overlay at bootup.
+          CHECK(overlays.contains(overlay.info().name()));
 
           LOG(INFO) << "reserving IPv6 " << stringify(network6.get());
           Try<Nothing> result =

--- a/overlay/messages.proto
+++ b/overlay/messages.proto
@@ -61,6 +61,7 @@ message AgentNetworkConfig {
 
   // Timeout for calls to docker deamon and networking tools, ms
   optional uint32 command_timeout = 5 [default = 15000];
+  optional bool enable_ipv6 = 6 [default = true];
 }
 
 

--- a/tests/overlay_tests.cpp
+++ b/tests/overlay_tests.cpp
@@ -289,12 +289,17 @@ protected:
     return Owned<Anonymous>(create.get());
   }
 
-  // This takes in a user defined `_masterOverlayConfig` and merges
-  // with the already initialized `masterOverlayConfig`.
+  // This takes in a user defined `_masterOverlayConfig` and a merge flag.
+  // If the merge flag is true then it merges `_masterOverlayConfig` with
+  // the already initialized `masterOverlayConfig`.
   Try<Owned<Anonymous>> startOverlayMaster(
-      const MasterConfig& _masterOverlayConfig)
+      const MasterConfig& _masterOverlayConfig, bool merge = true)
   {
-    masterOverlayConfig.MergeFrom(_masterOverlayConfig);
+    if (merge) {
+      masterOverlayConfig.MergeFrom(_masterOverlayConfig);
+    } else {
+      masterOverlayConfig = _masterOverlayConfig;
+    }
     return startOverlayMaster();
   }
 
@@ -949,13 +954,13 @@ TEST_F(OverlayTest, ROOT_checkAgentRecovery)
   ASSERT_SOME(allocatedSubnet6);
   EXPECT_EQ(allocatedSubnet6.get(), agentNetwork6.get());
 
-  // Re-start the agent and wait for the agent to re-register.
-  Future<AgentRegisteredAcknowledgement> agentReRegisteredAcknowledgement =
-    FUTURE_PROTOBUF(AgentRegisteredAcknowledgement(), _, _);
-
   // Kill the agent.
   Try<Nothing> stop = stopOverlayAgent();
   ASSERT_SOME(stop);
+
+  // Re-start the agent and wait for the agent to re-register.
+  Future<AgentRegisteredAcknowledgement> agentReRegisteredAcknowledgement =
+    FUTURE_PROTOBUF(AgentRegisteredAcknowledgement(), _, _);
 
   // re-start the agent.
   agentModule  = startOverlayAgent(agentOverlayConfig);
@@ -1486,6 +1491,242 @@ TEST_F(OverlayTest, checkMTUConfiguration)
 
   // MTU should be equal to the value in master configuration
   ASSERT_EQ(9000, info->overlays(0).backend().vxlan().vtep_mtu());
+}
+
+
+//Test enable/disable IPv6 configuration
+TEST_F(OverlayTest, ROOT_checkEnableDisableIPv6Configuration)
+{
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+  LOG(INFO) << "Master PID: " << master.get()->pid;
+
+  Try<Owned<Anonymous>> masterModule = startOverlayMaster();
+  ASSERT_SOME(masterModule);
+
+  // Master `Anonymous` module created successfully.
+  UPID overlayMaster = UPID(
+      MASTER_MANAGER_PROCESS_ID,
+      master.get()->pid.address);
+
+  AgentConfig agentOverlayConfig;
+  agentOverlayConfig.set_master(stringify(overlayMaster.address));
+
+  // Enable docker bridge. IPv6 is enabled by default so
+  // this should create an IPv6 docker bridge
+  agentOverlayConfig.mutable_network_config()->set_docker_bridge(true);
+
+  // Setup futures to notify the test that Agent overlay module has
+  // registered.
+  Future<AgentRegisteredMessage> agentRegisteredMessage =
+    FUTURE_PROTOBUF(AgentRegisteredMessage(), _, _);
+
+  Try<Owned<overlayAgent::ManagerProcess>> agentModule = startOverlayAgent(
+      agentOverlayConfig);
+
+  ASSERT_SOME(agentModule);
+
+  AWAIT_READY(agentRegisteredMessage);
+
+  // Check the agent is allowed to progress.
+  AWAIT_READY(agentModule.get()->ready());
+
+  // Verify the docker network has been installed correctly.
+  Future<string> docker = runCommand("docker",
+      {"docker",
+       "network",
+       "inspect",
+       OVERLAY_NAME});
+
+  AWAIT_READY(docker);
+
+  Try<JSON::Array> json = JSON::parse<JSON::Array>(docker.get());
+  ASSERT_SOME(json);
+
+  // Verify that IPv6 is enabled on docker network
+  Result<JSON::Boolean> ipv6Flag =
+      json->values[0].as<JSON::Object>().find<JSON::Boolean>("EnableIPv6");
+  ASSERT_SOME(ipv6Flag);
+  EXPECT_EQ(ipv6Flag.get(), true);
+
+  // kill the agent
+  Try<Nothing> stop = stopOverlayAgent();
+  ASSERT_SOME(stop);
+
+  // Remove docker network
+  docker = runCommand(
+      "docker",
+      {"docker",
+       "network",
+       "rm",
+       OVERLAY_NAME});
+  AWAIT_READY(docker);
+
+  // Disable IPv6
+  agentOverlayConfig.mutable_network_config()->set_enable_ipv6(false);
+
+  // Re-start the agent and wait for the agent to re-register.
+  Future<AgentRegisteredMessage> agentReRegisteredMessage =
+    FUTURE_PROTOBUF(AgentRegisteredMessage(), _, _);
+
+  // re-start the agent.
+  agentModule  = startOverlayAgent(agentOverlayConfig);
+  ASSERT_SOME(agentModule);
+
+  AWAIT_READY(agentReRegisteredMessage);
+
+  // Check the agent is allowed to progress.
+  AWAIT_READY(agentModule.get()->ready());
+
+  // Verify the docker network has been installed correctly.
+  docker = runCommand("docker",
+      {"docker",
+       "network",
+       "inspect",
+       OVERLAY_NAME});
+
+  AWAIT_READY(docker);
+
+  json = JSON::parse<JSON::Array>(docker.get());
+  ASSERT_SOME(json);
+
+  // Verify that IPv6 is disabled in docker network
+  ipv6Flag = json->values[0].as<JSON::Object>().find<JSON::Boolean>("EnableIPv6");
+  ASSERT_SOME(ipv6Flag);
+  EXPECT_EQ(ipv6Flag.get(), false);
+}
+
+
+// Tests dynamic addition of IPv6 subnet
+TEST_F(OverlayTest, checkIPv6Configuration)
+{
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+  LOG(INFO) << "Master PID: " << master.get()->pid;
+
+  // Ask overlay Master to use the replicated log by setting
+  // `replicated_log_dir`. We are not specifying `zk` configuration so
+  // the `quorum` will default to "1".
+  MasterConfig masterOverlayConfig;
+  masterOverlayConfig
+    .set_replicated_log_dir("overlay_replicated_log");
+
+  // Create a IPv4 only Overlay
+  masterOverlayConfig.mutable_network()->set_vtep_subnet("44.128.0.0/16");
+  masterOverlayConfig.mutable_network()->set_vtep_mac_oui(
+      "70:B3:D5:00:00:00");
+
+  OverlayInfo overlay;
+  overlay.set_name(OVERLAY_NAME);
+  overlay.set_subnet(OVERLAY_SUBNET);
+  overlay.set_prefix(OVERLAY_PREFIX);
+
+  masterOverlayConfig.mutable_network()->add_overlays()->CopyFrom(overlay);
+
+  Try<Owned<Anonymous>> masterModule =
+      startOverlayMaster(masterOverlayConfig, false);
+  ASSERT_SOME(masterModule);
+
+  // Master `Anonymous` module created successfully.
+  UPID overlayMaster = UPID(
+      MASTER_MANAGER_PROCESS_ID,
+      master.get()->pid.address);
+
+  AgentConfig agentOverlayConfig;
+  agentOverlayConfig.set_master(stringify(overlayMaster.address));
+  // Set number of times the agent will attempt to configure virtual
+  // networks by re-registering with the master.
+  agentOverlayConfig.set_max_configuration_attempts(1);
+
+  // Setup futures to notify the test that Agent overlay module has
+  // registered.
+  Future<AgentRegisteredAcknowledgement> agentRegisteredAcknowledgement =
+    FUTURE_PROTOBUF(AgentRegisteredAcknowledgement(), _, _);
+
+  Try<Owned<overlayAgent::ManagerProcess>> agentModule = startOverlayAgent(
+      agentOverlayConfig);
+
+  AWAIT_READY(agentRegisteredAcknowledgement);
+
+  ASSERT_SOME(agentModule);
+
+  // Check the agent is allowed to progress.
+  AWAIT_READY(agentModule.get()->ready());
+
+  // Hit the `overlay` endpoint of the agent to check that
+  // there is no ipv6 subnet on vtep interface
+  UPID overlayAgent = UPID(master.get()->pid);
+  overlayAgent.id = AGENT_MANAGER_PROCESS_ID;
+
+  Future<Response> agentResponse = process::http::get(
+      overlayAgent,
+      "overlay");
+
+  AWAIT_EXPECT_RESPONSE_STATUS_EQ(OK().status, agentResponse);
+  AWAIT_EXPECT_RESPONSE_HEADER_EQ(
+      APPLICATION_JSON,
+      "Content-Type",
+      agentResponse);
+
+  Try<AgentInfo> info = parseAgentOverlay(agentResponse->body);
+  ASSERT_SOME(info);
+
+  // Verify that vtep_ip6 is not present
+  ASSERT_FALSE(info.get().overlays(0).backend().vxlan().has_vtep_ip6());
+
+  // kill the master
+  masterModule->reset();
+
+  // setup ipv6 address on vtep
+  masterOverlayConfig.mutable_network()->set_vtep_subnet6("fd03::/64");
+
+  // Add an overlay network with IPv6 configuration
+  overlay.clear_subnet();
+  overlay.clear_prefix();
+  overlay.set_name("mz-test-ip6");
+  overlay.set_subnet6("fd04::/64");
+  overlay.set_prefix6(OVERLAY_PREFIX6);
+
+  masterOverlayConfig.mutable_network()->add_overlays()->CopyFrom(overlay);
+
+  masterModule = startOverlayMaster(masterOverlayConfig, false);
+  ASSERT_SOME(masterModule);
+
+  // Re-start the master and wait for the Agent to re-register
+  agentRegisteredAcknowledgement = FUTURE_PROTOBUF(
+      AgentRegisteredAcknowledgement(), _, _);
+
+  AWAIT_READY(agentRegisteredAcknowledgement);
+
+  // Hit the `overlay` endpoint of the agent to check that module is
+  // up and responding
+  agentResponse = process::http::get(overlayAgent, "overlay");
+
+  AWAIT_EXPECT_RESPONSE_STATUS_EQ(OK().status, agentResponse);
+  AWAIT_EXPECT_RESPONSE_HEADER_EQ(
+      APPLICATION_JSON,
+      "Content-Type",
+      agentResponse);
+
+  // parse the agent config
+  info = parseAgentOverlay(agentResponse->body);
+  ASSERT_SOME(info);
+
+  // There should be 2 overlays.
+  ASSERT_EQ(2, info->overlays_size());
+
+  Option<AgentOverlayInfo> agentOverlay;
+  foreach(const AgentOverlayInfo& _agentOverlay, info->overlays()) {
+    if (_agentOverlay.info().name() == "mz-test-ip6") {
+      agentOverlay = _agentOverlay;
+      break;
+    }
+  }
+
+  ASSERT_SOME(agentOverlay);
+  ASSERT_FALSE(agentOverlay->has_subnet());
+  ASSERT_EQ(agentOverlay->subnet6(), "fd04::/80");
+  ASSERT_EQ(agentOverlay->backend().vxlan().vtep_ip6(), "fd03::1/64");
 }
 
 } // namespace tests {


### PR DESCRIPTION
more details can be found here https://jira.mesosphere.com/browse/COPS-3231. 

The issue happened during the upgrade from 1.10.x to 1.11.x wherein the ipv6 address was not added to an existing vtep interface which resulted in failure to configure ipv6 overlay on the agent. This patch fixes the issue by adding ipv6 address to an existing vtep interface.

During debugging of the above issue, it was discovered that ipv6 disable functionality was breaking the overlay module. Reason being, the overlay module doesn't support deletion of an existing overlay network. This patch also fixes that issue by introducing an `enable_ipv6` flag to provide ipv6 disable functionality. The default value of the flag is true i.e. ipv6 is enabled by default.