### PR TITLE
Removed unneeded picojson definition.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,7 +344,7 @@ AC_CHECK_HEADERS([boost/lexical_cast.hpp boost/functional/hash.hpp],
                 [AC_MSG_ERROR([boost is not installed.])])
 
 AC_CHECK_HEADER([picojson.h],
-                [MESOS_CPPFLAGS+=" -DPICOJSON_USE_INT64 -D__STDC_FORMAT_MACROS"],
+                [MESOS_CPPFLAGS+=" -D__STDC_FORMAT_MACROS"],
                 [AC_MSG_ERROR([picojson is not installed.])])
 
 # Check for the systemd journal header.


### PR DESCRIPTION
Mesos recently made it unnecessary to manually define
PICOJSON_USE_INT64 to use its stout/json.hpp header. For that they
move the definition into the header itself. We currently still manually
define this flag which leads to a (intentionally made fatal) warning
about a macro redefinition.

This patch removes our defintion.

This PR and description is taken from the corresponding EE PR: https://github.com/mesosphere/dcos-ee-mesos-modules/pull/273