### PR TITLE
Adds dataDir in the host-local ipam configuration

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -207,9 +207,15 @@ Try<Owned<ManagerProcess>> ManagerProcess::create(
     }
   }
 
+  Option<string> cniDataDir;
+  if (agentConfig.has_cni_data_dir()) {
+    cniDataDir = agentConfig.cni_data_dir();
+  }
+
   return Owned<ManagerProcess>(
       new ManagerProcess(
         agentConfig.cni_dir(),
+        cniDataDir,
         networkConfig,
         agentConfig.max_configuration_attempts(),
         Owned<MasterDetector>(detector.get())));
@@ -705,7 +711,9 @@ Future<Nothing> ManagerProcess::configureMesosNetwork(const string& name)
   AgentNetworkConfig _networkConfig;
   _networkConfig.CopyFrom(networkConfig);
 
-  auto config = [name, subnet, overlay, _networkConfig](
+  Option<string> _cniDataDir = cniDataDir;
+
+  auto config = [name, subnet, overlay, _cniDataDir, _networkConfig](
       JSON::ObjectWriter* writer) {
     writer->field("name", name);
     writer->field("type", "mesos-cni-port-mapper");
@@ -715,15 +723,18 @@ Future<Nothing> ManagerProcess::configureMesosNetwork(const string& name)
     });
     writer->field("chain", strings::upper(overlay.mesos_bridge().name())),
     writer->field("delegate",
-      [subnet, overlay, _networkConfig](JSON::ObjectWriter* writer) {
+      [subnet, overlay, _cniDataDir, _networkConfig](JSON::ObjectWriter* writer) {
         writer->field("type", "bridge");
         writer->field("bridge", overlay.mesos_bridge().name());
         writer->field("isGateway", true);
         writer->field("ipMasq", false);
         writer->field("mtu", _networkConfig.overlay_mtu());
 
-        writer->field("ipam", [subnet](JSON::ObjectWriter* writer) {
+        writer->field("ipam", [subnet, _cniDataDir](JSON::ObjectWriter* writer) {
           writer->field("type", "host-local");
+          if (_cniDataDir.isSome()) {
+            writer->field("dataDir", _cniDataDir.get());
+          }
           writer->field("subnet", stringify(subnet.get()));
 
           writer->field("routes", [](JSON::ArrayWriter* writer) {
@@ -907,11 +918,13 @@ Future<Nothing> ManagerProcess::__configureDockerNetwork(
 
 ManagerProcess::ManagerProcess(
     const string& _cniDir,
+    Option<string> _cniDataDir,
     const AgentNetworkConfig _networkConfig,
     const uint32_t _maxConfigAttempts,
     Owned<MasterDetector> _detector)
 : ProcessBase(AGENT_MANAGER_PROCESS_ID),
   cniDir(_cniDir),
+  cniDataDir(_cniDataDir),
   networkConfig(_networkConfig),
   maxConfigAttempts(_maxConfigAttempts),
   detector(_detector)

--- a/overlay/agent.hpp
+++ b/overlay/agent.hpp
@@ -74,11 +74,14 @@ private:
 
   ManagerProcess(
       const std::string& _cniDir,
+      Option<std::string> _cniDataDir,
       const overlay::internal::AgentNetworkConfig _networkConfig,
       const uint32_t _maxConfigAttempts,
       process::Owned<master::detector::MasterDetector> _detector);
 
   const std::string cniDir;
+
+  Option<std::string> cniDataDir;
 
   const overlay::internal::AgentNetworkConfig networkConfig;
 

--- a/overlay/messages.proto
+++ b/overlay/messages.proto
@@ -73,6 +73,7 @@ message AgentConfig {
   // Number of times the agent will attempt to configure virtual
   // networks by re-registering with the master.
   optional uint32 max_configuration_attempts = 4 [default = 4];
+  optional string cni_data_dir = 5;
 }
 
 


### PR DESCRIPTION
Currently, host-local ipam cni plugin uses a persistent location
on the disk as its data dir where it keeps the information about
allocated IP addresses. This leads to orphan IP addresses if
the agent reboots. This patch moves the data dir to a tmpfs location
so that all the allocated IP addresses are recycled upon agent reboot.

jira ticket: DCOS_OSS-3750