### PR TITLE
Fixes an issue with the iptables rules in Overlay

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -848,7 +848,8 @@ Future<Nothing> ManagerProcess::_configureDockerNetwork(
 {
   if (exists) {
     LOG(INFO) << "Docker network '" << name << "' already exists";
-    return Nothing();
+    // we still need to fix the iptables rule
+    return __configureDockerNetwork(name, "");
   }
 
   CHECK(overlays.contains(name));


### PR DESCRIPTION
Docker isolates its networks by adding an explicit DROP iptables rules
for any cross communication. However, Overlay (which uses
docker network) allows seamless communication among Docker networks.
So, Overlay by-passes Docker isolation by adding an explicit RETURN
as the first iptables rule in the chain. However, due to a bug,
Overlay missed adding that rule if Docker network is already
present. This patch fixes that issue

jira ticket: DCOS_OSS-3697