### PR TITLE
Adds dataDir in the host-local ipam configuration

### DIFF
--- a/overlay/agent.hpp
+++ b/overlay/agent.hpp
@@ -74,11 +74,14 @@ private:
 
   ManagerProcess(
       const std::string& _cniDir,
+      Option<std::string> _cniDataDir,
       const overlay::internal::AgentNetworkConfig _networkConfig,
       const uint32_t _maxConfigAttempts,
       process::Owned<master::detector::MasterDetector> _detector);
 
   const std::string cniDir;
+
+  Option<std::string> cniDataDir;
 
   const overlay::internal::AgentNetworkConfig networkConfig;
 

--- a/overlay/messages.proto
+++ b/overlay/messages.proto
@@ -62,6 +62,7 @@ message AgentConfig {
   // Number of times the agent will attempt to configure virtual
   // networks by re-registering with the master.
   optional uint32 max_configuration_attempts = 4 [default = 4];
+  optional string cni_data_dir = 5;
 }
 
 


### PR DESCRIPTION
Currently, host-local ipam cni plugin uses a persistent location
on the disk as its data dir where it keeps the information about
allocated IP addresses. This leads to orphan IP addresses if
the agent reboots. This patch moves the data dir to a tmpfs location
so that all the allocated IP addresses are recycled upon agent reboot.

jira ticket: DCOS_OSS-3750