### PR TITLE
Add the metrics module.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,11 +98,23 @@ liblogsink_la_LDFLAGS =					\
 # Mesos Isolator Module.
 ###############################################################################
 
+METRICS_PROTOS =					\
+  metrics/messages.pb.cc				\
+  metrics/messages.pb.h
+
+# Targets for generating C++ protocol buffer code.
+metrics/%.pb.cc metrics/%.pb.h: $(top_srcdir)/metrics/%.proto
+	$(PROTOC) $(PROTOCFLAGS) --cpp_out=. $^
+
+BUILT_SOURCES += $(METRICS_PROTOS)
+CLEANFILES += $(METRICS_PROTOS)
+
 # Library with the MetricsIsolator module.
 pkglib_LTLIBRARIES += libmetrics-module.la
 libmetrics_module_la_SOURCES =				\
   metrics/isolator.hpp					\
-  metrics/isolator.cpp
+  metrics/isolator.cpp					\
+  ${METRICS_PROTOS}
 
 libmetrics_module_la_LDFLAGS =				\
   -release $(PACKAGE_VERSION)				\

--- a/Makefile.am
+++ b/Makefile.am
@@ -95,6 +95,20 @@ liblogsink_la_LDFLAGS =					\
   -shared $(MESOS_LDFLAGS)
 
 ###############################################################################
+# Mesos Isolator Module.
+###############################################################################
+
+# Library with the MetricsIsolator module.
+pkglib_LTLIBRARIES += libmetrics-module.la
+libmetrics_module_la_SOURCES =				\
+  metrics/isolator.hpp					\
+  metrics/isolator.cpp
+
+libmetrics_module_la_LDFLAGS =				\
+  -release $(PACKAGE_VERSION)				\
+  -shared $(MESOS_LDFLAGS)
+
+###############################################################################
 # Overlay Modules.
 ###############################################################################
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -242,6 +242,22 @@ test_logsink_LDADD =					\
   libmesos_tests.la					\
   liblogsink.la
 
+# Test (make check) binary for the Metrics module.
+check_PROGRAMS += test-metrics
+
+test_metrics_SOURCES =                                 \
+  tests/metrics_tests.cpp
+
+test_metrics_CPPFLAGS =                                        \
+  $(libmesos_tests_la_CPPFLAGS)
+
+test_metrics_LDADD =                                   \
+  $(MESOS_LDFLAGS)                                     \
+  $(MESOS_BUILD_DIR)/$(BUNDLE_SUBDIR)/.libs/libgmock.la        \
+  $(MESOS_BUILD_DIR)/src/.libs/libmesos.la             \
+  libmesos_tests.la                                    \
+  libmetrics-module.la
+
 # Test (make check) binary for the overlay modules.
 check_PROGRAMS += test-overlay
 
@@ -279,4 +295,5 @@ check-local: $(check_PROGRAMS)
 	./test-dockercfg
 	./test-journald --verbose
 	./test-logsink --verbose
+	./test-metrics --verbose
 	LIBPROCESS_IP=127.0.0.1 LIBPROCESS_PORT=5050 ./test-overlay --verbose

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,7 @@ fi
 AC_CONFIG_FILES([dockercfg/modules.json], [])
 AC_CONFIG_FILES([journald/modules.json], [])
 AC_CONFIG_FILES([logsink/modules.json], [])
+AC_CONFIG_FILES([metrics/modules.json], [])
 AC_CONFIG_FILES([overlay/agent_modules.json], [])
 AC_CONFIG_FILES([overlay/master_modules.json], [])
 

--- a/metrics/isolator.cpp
+++ b/metrics/isolator.cpp
@@ -1,0 +1,209 @@
+#include <map>
+#include <string>
+#include <vector>
+
+#include <mesos/mesos.hpp>
+#include <mesos/module.hpp>
+
+#include <mesos/module/isolator.hpp>
+#include <mesos/module/module.hpp>
+
+#include <process/address.hpp>
+#include <process/defer.hpp>
+#include <process/future.hpp>
+#include <process/process.hpp>
+
+#include <stout/assert.hpp>
+#include <stout/hashset.hpp>
+#include <stout/ip.hpp>
+#include <stout/nothing.hpp>
+#include <stout/numify.hpp>
+#include <stout/option.hpp>
+#include <stout/os.hpp>
+#include <stout/path.hpp>
+#include <stout/strings.hpp>
+#include <stout/try.hpp>
+
+#include "isolator.hpp"
+
+#include "metrics/messages.pb.h"
+
+namespace inet = process::network::inet;
+namespace unix = process::network::unix;
+
+using namespace mesos;
+using namespace process;
+
+using std::map;
+using std::string;
+using std::vector;
+
+using mesos::slave::ContainerLaunchInfo;
+using mesos::slave::ContainerState;
+using mesos::slave::Isolator;
+
+namespace mesosphere {
+namespace dcos {
+namespace metrics {
+
+class MetricsIsolatorProcess
+  : public process::Process<MetricsIsolatorProcess>
+{
+public:
+  MetricsIsolatorProcess(const isolator::Flags& _flags) : flags(_flags)
+  {
+    // Set `serviceScheme` based on flags.
+    ASSERT(flags.service_scheme.isSome());
+    ASSERT(flags.service_scheme.get() == "http" ||
+           flags.service_scheme.get() == "https");
+    serviceScheme = flags.service_scheme.get();
+
+    // Set `service*Address` based on flags.
+    ASSERT(flags.service_address.isSome());
+
+    ASSERT(flags.service_network.isSome());
+    ASSERT(flags.service_network.get() == "inet" ||
+           flags.service_network.get() == "unix");
+
+    if (flags.service_network.get() == "inet") {
+      vector<string> hostport =
+        strings::split(flags.service_address.get(), ":");
+      if (hostport.size() != 2) {
+        LOG(FATAL) << "Unable to split '" << flags.service_address.get() << "'"
+                   << " into valid 'host:port' combination";
+      }
+
+      Try<net::IP> ip = net::IP::parse(hostport[0]);
+      if (ip.isError()) {
+        LOG(FATAL) << "Unable to parse '" << hostport[0] << "'"
+                   << " as a valid IP address: " << ip.error();
+      }
+
+      Try<uint16_t> port = numify<uint16_t>(hostport[1]);
+      if (port.isError()) {
+        LOG(FATAL) << "Unable parse '" + hostport[1] + "'"
+                   << " as a valid port of type 'uint16_t': " + port.error();
+      }
+
+      serviceInetAddress = inet::Address(ip.get(), port.get());
+    }
+
+    if (flags.service_network.get() == "unix") {
+      Try<unix::Address> address =
+        unix::Address::create(flags.service_address.get());
+      if (address.isError()) {
+        LOG(FATAL) << "Unable to convert '" + flags.service_address.get() + "'"
+                   << " to valid 'unix' address: " + address.error();
+      }
+
+      serviceUnixAddress = address.get();
+    }
+
+    // Set `serviceEndpoint` based on flags.
+    ASSERT(flags.service_endpoint.isSome());
+    serviceEndpoint = flags.service_endpoint.get();
+  }
+
+  // Let the metrics service know about the container being launched.
+  // In the response, grab the STATSD_UDP_HOST and STATSD_UDP_PORT
+  // pair being returned and set it in the environment of the
+  // `ContainerLaunchInfo` returned from this function.
+  virtual Future<Option<ContainerLaunchInfo>> prepare(
+      const ContainerID& containerId,
+      const slave::ContainerConfig& containerConfig)
+  {
+    // Let the metrics service know about the container being
+    // launched via an HTTP request. In the response, grab the
+    // STATSD_UDP_HOST and STATSD_UDP_PORT pair being returned and set
+    // it in the environment of the `ContainerLaunchInfo` returned
+    // from this function. On any errors, return a `Failure()`.
+    ContainerLaunchInfo launchInfo;
+    return launchInfo;
+  }
+
+  virtual Future<Nothing> cleanup(
+      const ContainerID& containerId)
+  {
+    // Let the metrics service know about the container being
+    // destroyed via an HTTP request. On any errors, return an
+    // `Failure()`.
+    return Nothing();
+  }
+
+private:
+  const isolator::Flags flags;
+  string serviceScheme;
+  string serviceEndpoint;
+  Option<inet::Address> serviceInetAddress;
+  Option<unix::Address> serviceUnixAddress;
+};
+
+
+MetricsIsolator::MetricsIsolator(const isolator::Flags& flags)
+  : process(new MetricsIsolatorProcess(flags))
+{
+  spawn(process.get());
+}
+
+
+MetricsIsolator::~MetricsIsolator()
+{
+  terminate(process.get());
+  wait(process.get());
+}
+
+
+Future<Option<ContainerLaunchInfo>> MetricsIsolator::prepare(
+    const ContainerID& containerId,
+    const slave::ContainerConfig& containerConfig)
+{
+  return dispatch(process.get(),
+                  &MetricsIsolatorProcess::prepare,
+                  containerId,
+                  containerConfig);
+}
+
+
+Future<Nothing> MetricsIsolator::cleanup(
+    const ContainerID& containerId)
+{
+  return dispatch(process.get(),
+                  &MetricsIsolatorProcess::cleanup,
+                  containerId);
+}
+
+} // namespace metrics {
+} // namespace dcos {
+} // namespace mesosphere {
+
+mesos::modules::Module<Isolator>
+com_mesosphere_dcos_MetricsIsolatorModule(
+    MESOS_MODULE_API_VERSION,
+    MESOS_VERSION,
+    "Mesosphere",
+    "support@mesosphere.com",
+    "Metrics Isolator Module.",
+    nullptr,
+    [](const Parameters& parameters) -> Isolator* {
+      // Convert `parameters` into a map.
+      map<string, string> values;
+      foreach (const Parameter& parameter, parameters.parameter()) {
+        values[parameter.key()] = parameter.value();
+      }
+
+      mesosphere::dcos::metrics::isolator::Flags flags;
+
+      // Load and validate flags.
+      Try<flags::Warnings> load = flags.load(values, false);
+
+      if (load.isError()) {
+        LOG(ERROR) << "Failed to parse parameters: " << load.error();
+        return nullptr;
+      }
+
+      foreach (const flags::Warning& warning, load->warnings) {
+        LOG(WARNING) << warning.message;
+      }
+
+      return new mesosphere::dcos::metrics::MetricsIsolator(flags);
+    });

--- a/metrics/isolator.cpp
+++ b/metrics/isolator.cpp
@@ -42,6 +42,10 @@ using mesos::slave::ContainerLaunchInfo;
 using mesos::slave::ContainerState;
 using mesos::slave::Isolator;
 
+using mesos::modules::metrics::ContainerStartRequest;
+using mesos::modules::metrics::ContainerStartResponse;
+using mesos::modules::metrics::LegacyState;
+
 namespace mesosphere {
 namespace dcos {
 namespace metrics {

--- a/metrics/isolator.cpp
+++ b/metrics/isolator.cpp
@@ -17,16 +17,14 @@
 #include <stout/assert.hpp>
 #include <stout/hashset.hpp>
 #include <stout/ip.hpp>
-#include <stout/json.hpp>
 #include <stout/nothing.hpp>
 #include <stout/numify.hpp>
 #include <stout/option.hpp>
 #include <stout/os.hpp>
 #include <stout/path.hpp>
+#include <stout/protobuf.hpp>
 #include <stout/strings.hpp>
 #include <stout/try.hpp>
-
-#include <stout/flags/parse.hpp>
 
 #include "isolator.hpp"
 

--- a/metrics/isolator.hpp
+++ b/metrics/isolator.hpp
@@ -17,12 +17,34 @@
 #include <stout/duration.hpp>
 #include <stout/flags.hpp>
 #include <stout/hashset.hpp>
+#include <stout/json.hpp>
 #include <stout/option.hpp>
 #include <stout/try.hpp>
+
+#include <stout/flags/parse.hpp>
 
 namespace mesosphere {
 namespace dcos {
 namespace metrics {
+
+// TODO(greggomann): Remove this once we have an equivalent helper in stout.
+// See https://reviews.apache.org/r/68543/.
+template<typename T>
+Try<T> parse(const std::string& body)
+{
+  Try<JSON::Object> json = JSON::parse<JSON::Object>(body);
+  if (json.isError()) {
+    return Error("Error parsing input as JSON: " + json.error());
+  }
+
+  Try<T> response = ::protobuf::parse<T>(json.get());
+  if (response.isError()) {
+    return Error(
+        "Error parsing JSON into protobuf: " + response.error());
+  }
+
+  return response.get();
+}
 
 // Forward declaration.
 class MetricsIsolatorProcess;

--- a/metrics/isolator.hpp
+++ b/metrics/isolator.hpp
@@ -1,0 +1,142 @@
+#ifndef __METRICS_ISOLATOR_MODULE_HPP__
+#define __METRICS_ISOLATOR_MODULE_HPP__
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <mesos/mesos.hpp>
+#include <mesos/module.hpp>
+
+#include <mesos/slave/isolator.hpp>
+
+#include <process/future.hpp>
+#include <process/owned.hpp>
+#include <process/process.hpp>
+
+#include <stout/duration.hpp>
+#include <stout/flags.hpp>
+#include <stout/hashset.hpp>
+#include <stout/option.hpp>
+#include <stout/try.hpp>
+
+namespace mesosphere {
+namespace dcos {
+namespace metrics {
+
+// Forward declaration.
+class MetricsIsolatorProcess;
+
+namespace isolator {
+
+struct Flags : virtual flags::FlagsBase
+{
+  Flags()
+  {
+    add(&Flags::service_scheme,
+        "dcos_metrics_service_scheme",
+        "The scheme on which the --dcos_metrics_service_address is reachable.\n"
+        "Must be either \"http\" or \"https\".",
+        [](const Option<std::string>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("Missing required option"
+                         " --dcos_metrics_service_scheme");
+          }
+
+          if (value.get() != "http" && value.get() != "https") {
+            return Error("Expected --dcos_metrics_service_scheme"
+                         " to be either \"http\" or \"https\"");
+          }
+
+          return None();
+        });
+
+    add(&Flags::service_network,
+        "dcos_metrics_service_network",
+        "The network where the --dcos_metrics_service_address is reachable.\n"
+        "Must be either \"inet\" or \"unix\".",
+        [](const Option<std::string>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("Missing required option"
+                         " --dcos_metrics_service_network");
+          }
+
+          if (value.get() != "inet" && value.get() != "unix") {
+            return Error("Expected --dcos_metrics_service_network"
+                         " to be either \"inet\" or \"unix\"");
+          }
+
+          return None();
+        });
+
+    add(&Flags::service_address,
+        "dcos_metrics_service_address",
+        "The address where the DC/OS metrics service is reachable.",
+        [](const Option<std::string>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("Missing required option"
+                         " --dcos_metrics_service_address");
+          }
+
+          return None();
+        });
+
+    add(&Flags::service_endpoint,
+        "dcos_metrics_service_endpoint",
+        "The endpoint on the --dcos_metrics_service_address that\n"
+        "this module should communicate with.",
+        [](const Option<std::string>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("Missing required option"
+                         " --dcos_metrics_service_endpoint");
+          }
+
+          return None();
+        });
+
+    add(&Flags::request_timeout,
+        "request_timeout",
+        "The duration after which a request to the metrics service will\n"
+        "timeout and be considered failed.",
+        Seconds(5));
+  }
+
+  // TODO(greggomann): Remove the `Option`s here once we have an overload of
+  // `add()` which accepts required flags without a default value and with a
+  // validation function.
+  Option<std::string> service_scheme;
+  Option<std::string> service_network;
+  Option<std::string> service_address;
+  Option<std::string> service_endpoint;
+  Duration request_timeout;
+};
+
+} // namespace isolator
+
+
+class MetricsIsolator : public mesos::slave::Isolator
+{
+public:
+  MetricsIsolator(const isolator::Flags& flags);
+
+  virtual ~MetricsIsolator();
+
+  virtual process::Future<Option<mesos::slave::ContainerLaunchInfo>> prepare(
+      const mesos::ContainerID& containerId,
+      const mesos::slave::ContainerConfig& containerConfig) override;
+
+  virtual process::Future<Nothing> cleanup(
+      const mesos::ContainerID& containerId) override;
+
+  virtual bool supportsNesting() override { return true; }
+  virtual bool supportsStandalone() override { return true; }
+
+private:
+  process::Owned<MetricsIsolatorProcess> process;
+};
+
+} // namespace metrics {
+} // namespace dcos {
+} // namespace mesosphere {
+
+#endif // __METRICS_ISOLATOR_MODULE_HPP__

--- a/metrics/messages.proto
+++ b/metrics/messages.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+
+package mesos.modules.metrics;
+
+message ContainerStartRequest {
+  // The ContainerID of the container to
+  // start listening for metrics from.
+  required string container_id = 1;
+}
+
+message ContainerStartResponse {
+  // The fields below are optional because in the future we want the
+  // metrics service to only create StatsD listeners for containers
+  // corresponding to tasks that are labeled with
+  // `DCOS_METRICS_FORMAT=statsd`. For DC/OS 1.12, however, these will
+  // always be filled in.
+  optional string statsd_host = 1;
+  optional int32 statsd_port = 2;
+}
+
+message ContainerStopRequest {
+  // The ContainerID of the container to
+  // stop listening for metrics from.
+  required string container_id = 1;
+}
+
+message ContainerStopResponse {}

--- a/metrics/modules.json.in
+++ b/metrics/modules.json.in
@@ -4,10 +4,10 @@
         "modules": [ {
             "name": "com_mesosphere_dcos_MetricsIsolatorModule",
             "parameters": [
-                {"key": "service_scheme", "value": "https"},
-                {"key": "service_network", "value": "inet"},
-                {"key": "service_address", "value": "127.0.0.1:8124"},
-                {"key": "service_endpoint", "value": "/containers"},
+                {"key": "dcos_metrics_service_scheme", "value": "http"},
+                {"key": "dcos_metrics_service_network", "value": "inet"},
+                {"key": "dcos_metrics_service_address", "value": "127.0.0.1:8124"},
+                {"key": "dcos_metrics_service_endpoint", "value": "/container"},
                 {"key": "legacy_state_path_dir",
                  "value": "/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/"}
             ]

--- a/metrics/modules.json.in
+++ b/metrics/modules.json.in
@@ -1,0 +1,16 @@
+{
+    "libraries": [ {
+        "file": "@abs_top_builddir@/.libs/libmetrics-module.@LIB_EXT@",
+        "modules": [ {
+            "name": "com_mesosphere_dcos_MetricsIsolatorModule",
+            "parameters": [
+                {"key": "service_scheme", "value": "https"},
+                {"key": "service_network", "value": "inet"},
+                {"key": "service_address", "value": "127.0.0.1:8124"},
+                {"key": "service_endpoint", "value": "/containers"},
+                {"key": "legacy_state_path_dir",
+                 "value": "/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/"}
+            ]
+        }]
+    } ]
+}

--- a/tests/metrics_tests.cpp
+++ b/tests/metrics_tests.cpp
@@ -1,0 +1,678 @@
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+
+#include <mesos/mesos.hpp>
+#include <mesos/module.hpp>
+
+#include <mesos/module/isolator.hpp>
+#include <mesos/module/module.hpp>
+
+#include <mesos/slave/containerizer.hpp>
+#include <mesos/slave/isolator.hpp>
+
+#include <process/clock.hpp>
+#include <process/dispatch.hpp>
+#include <process/future.hpp>
+#include <process/gmock.hpp>
+#include <process/gtest.hpp>
+#include <process/http.hpp>
+#include <process/owned.hpp>
+#include <process/process.hpp>
+
+#include <stout/duration.hpp>
+#include <stout/gtest.hpp>
+#include <stout/hashmap.hpp>
+#include <stout/os.hpp>
+#include <stout/path.hpp>
+#include <stout/protobuf.hpp>
+#include <stout/strings.hpp>
+
+#include <stout/os/exists.hpp>
+#include <stout/os/read.hpp>
+
+#include "common/http.hpp"
+
+#include "metrics/messages.pb.h"
+#include "metrics/isolator.hpp"
+
+#include "module/manager.hpp"
+
+#include "tests/mesos.hpp"
+
+using namespace mesos::internal::tests;
+
+using mesos::modules::ModuleManager;
+
+using mesos::modules::metrics::ContainerStartRequest;
+using mesos::modules::metrics::ContainerStartResponse;
+
+using mesos::slave::Isolator;
+
+using mesosphere::dcos::metrics::MetricsIsolator;
+using mesosphere::dcos::metrics::parse;
+
+using process::Clock;
+using process::Future;
+using process::Owned;
+
+using std::string;
+using std::vector;
+
+using testing::DoAll;
+using testing::Return;
+
+namespace mesos {
+namespace metrics {
+namespace tests {
+
+const string METRICS_PROCESS = "metrics-service";
+const string API_PATH = "container";
+const Duration REQUEST_TIMEOUT = Seconds(5);
+
+
+class MetricsTest : public MesosTest
+{
+protected:
+  virtual void SetUp()
+  {
+    MesosTest::SetUp();
+
+    // Construct the metrics module configuration.
+    const string ip = stringify(process::address().ip);
+    const string port = stringify(process::address().port);
+    const Try<string> config = strings::format(R"~(
+        {
+          "libraries": [ {
+            "file": "%s",
+            "modules": [ {
+              "name": "com_mesosphere_dcos_MetricsIsolatorModule",
+              "parameters": [
+                {"key": "dcos_metrics_service_scheme", "value": "http"},
+                {"key": "dcos_metrics_service_network", "value": "inet"},
+                {"key": "dcos_metrics_service_address", "value": "%s"},
+                {"key": "dcos_metrics_service_endpoint", "value": "%s"},
+                {"key": "request_timeout", "value": "%s"}
+              ]
+            } ]
+          } ]
+        }
+        )~",
+        path::join(MODULES_BUILD_DIR, ".libs", "libmetrics-module.so"),
+        ip + ":" + port,
+        "/" + METRICS_PROCESS + "/" + API_PATH,
+        stringify(REQUEST_TIMEOUT));
+
+    ASSERT_SOME(config);
+
+    Try<JSON::Object> json = JSON::parse<JSON::Object>(config.get());
+    ASSERT_SOME(json);
+
+    Try<Modules> _modules = protobuf::parse<Modules>(json.get());
+    ASSERT_SOME(_modules);
+
+    modules = _modules.get();
+
+    // Initialize the metrics module.
+    Try<Nothing> result = ModuleManager::load(modules);
+    ASSERT_SOME(result);
+
+    // Create an instance of the module and store it for testing.
+    Try<Isolator*> isolator_ =
+      ModuleManager::create<Isolator>(
+          "com_mesosphere_dcos_MetricsIsolatorModule");
+
+    ASSERT_SOME(isolator_);
+    isolator = isolator_.get();
+  }
+
+  virtual void TearDown()
+  {
+    // Unload the metrics module.
+    foreach (const Modules::Library& library, modules.libraries()) {
+      foreach (const Modules::Library::Module& module, library.modules()) {
+        if (module.has_name()) {
+          ASSERT_SOME(ModuleManager::unload(module.name()));
+        }
+      }
+    }
+
+    MesosTest::TearDown();
+  }
+
+  Isolator* isolator;
+
+private:
+  Modules modules;
+};
+
+
+// Simulates the DC/OS metrics service.
+class MockMetricsServiceProcess
+  : public process::Process<MockMetricsServiceProcess>
+{
+public:
+  MockMetricsServiceProcess() : ProcessBase(METRICS_PROCESS) {}
+
+  MOCK_METHOD1(container, Future<process::http::Response>(
+      const process::http::Request&));
+
+protected:
+  void initialize() override
+  {
+    route("/" + API_PATH, None(), &MockMetricsServiceProcess::container);
+  }
+};
+
+
+class MockMetricsService
+{
+public:
+  MockMetricsService() : mock(new MockMetricsServiceProcess())
+  {
+    spawn(mock.get());
+  }
+
+  ~MockMetricsService()
+  {
+    terminate(mock.get());
+    wait(mock.get());
+  }
+
+  Owned<MockMetricsServiceProcess> mock;
+};
+
+
+// When the isolator's `prepare()` method is called with a container ID, it
+// should make an API call to the metrics service to retrieve the metrics port
+// for that container, and then inject the correct host and port into the
+// environment contained in the returned `ContainerLaunchInfo`.
+TEST_F(MetricsTest, PrepareSuccess)
+{
+  MockMetricsService metricsService;
+
+  ContainerStartResponse responseBody;
+  responseBody.set_statsd_port(1111);
+  responseBody.set_statsd_host("127.0.0.1");
+
+  process::http::Response response(
+      string(jsonify(JSON::Protobuf(responseBody))),
+      process::http::Status::CREATED,
+      "application/json");
+
+  Future<process::http::Request> request;
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(DoAll(FutureArg<0>(&request),
+                    Return(response)));
+
+  const string CONTAINER_ID = "new-container";
+
+  ContainerID containerId;
+  containerId.set_value(CONTAINER_ID);
+
+  Future<Option<mesos::slave::ContainerLaunchInfo>> prepared =
+    isolator->prepare(containerId, mesos::slave::ContainerConfig());
+
+  AWAIT_READY(request);
+
+  // Verify the contents of the module's request.
+  Try<ContainerStartRequest> requestBody =
+    parse<ContainerStartRequest>(request->body);
+
+  ASSERT_SOME(requestBody);
+  ASSERT_EQ(request->method, "POST");
+  ASSERT_FALSE(requestBody->has_statsd_host());
+  ASSERT_FALSE(requestBody->has_statsd_port());
+  ASSERT_EQ(requestBody->container_id(), CONTAINER_ID);
+
+  AWAIT_READY(prepared);
+
+  // Check that the `ContainerLaunchInfo` contains environment variables.
+  ASSERT_SOME(prepared.get());
+  ASSERT_TRUE(prepared.get()->has_environment());
+  ASSERT_GT(prepared.get()->environment().variables().size(), 0);
+
+  // Verify the contents of the returned environment.
+  hashmap<string, string> expectedEnvironment =
+    {{"STATSD_UDP_HOST", "127.0.0.1"},
+     {"STATSD_UDP_PORT", "1111"}};
+
+  foreach (const Environment::Variable& variable,
+           prepared.get()->environment().variables()) {
+    ASSERT_EQ(variable.type(), Environment::Variable::VALUE);
+    ASSERT_TRUE(variable.has_value());
+    ASSERT_EQ(variable.value(), expectedEnvironment[variable.name()]);
+  }
+}
+
+
+// When the isolator's `prepare()` method is called and the metrics service
+// returns a response which does not contain a port, the isolator should return
+// a failed future.
+TEST_F(MetricsTest, PrepareFailureNoPort)
+{
+  MockMetricsService metricsService;
+
+  ContainerStartResponse responseBody;
+  responseBody.set_statsd_host("127.0.0.1");
+
+  process::http::Response response(
+      string(jsonify(JSON::Protobuf(responseBody))),
+      process::http::Status::CREATED,
+      "application/json");
+
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(Return(response));
+
+  const string CONTAINER_ID = "new-container";
+
+  ContainerID containerId;
+  containerId.set_value(CONTAINER_ID);
+
+  Future<Option<mesos::slave::ContainerLaunchInfo>> prepared =
+    isolator->prepare(containerId, mesos::slave::ContainerConfig());
+
+  AWAIT_FAILED(prepared);
+}
+
+
+// When the isolator's `prepare()` method is called and the metrics service
+// returns a response code other than 201 CREATED, the isolator should return
+// a failed future.
+TEST_F(MetricsTest, PrepareFailureUnexpectedStatusCode)
+{
+  MockMetricsService metricsService;
+
+  ContainerStartResponse responseBody;
+  responseBody.set_statsd_port(1111);
+  responseBody.set_statsd_host("127.0.0.1");
+
+  process::http::Response response(
+      string(jsonify(JSON::Protobuf(responseBody))),
+      process::http::Status::OK,
+      "application/json");
+
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(Return(response));
+
+  const string CONTAINER_ID = "new-container";
+
+  ContainerID containerId;
+  containerId.set_value(CONTAINER_ID);
+
+  Future<Option<mesos::slave::ContainerLaunchInfo>> prepared =
+    isolator->prepare(containerId, mesos::slave::ContainerConfig());
+
+  AWAIT_FAILED(prepared);
+}
+
+
+// When the isolator's `prepare()` method is called and the metrics service
+// doesn't return a response within the configured request timeout, the isolator
+// should return a failed future.
+TEST_F(MetricsTest, PrepareFailureRequestTimeout)
+{
+  Clock::pause();
+
+  MockMetricsService metricsService;
+
+  ContainerStartResponse responseBody;
+  responseBody.set_statsd_port(1111);
+  responseBody.set_statsd_host("127.0.0.1");
+
+  Future<process::http::Response> response;
+
+  Future<Nothing> requestSent;
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(DoAll(FutureSatisfy(&requestSent),
+                    Return(response)));
+
+  const string CONTAINER_ID = "new-container";
+
+  ContainerID containerId;
+  containerId.set_value(CONTAINER_ID);
+
+  Future<Option<mesos::slave::ContainerLaunchInfo>> prepared =
+    isolator->prepare(containerId, mesos::slave::ContainerConfig());
+
+  AWAIT_READY(requestSent);
+
+  ASSERT_TRUE(prepared.isPending());
+
+  Clock::advance(REQUEST_TIMEOUT);
+  Clock::settle();
+
+  ASSERT_TRUE(prepared.isFailed());
+
+  Clock::resume();
+}
+
+
+// When the isolator's `cleanup()` method is called and the module receives a
+// 202 ACCEPTED response from the metrics service, the isolator should return a
+// ready future.
+TEST_F(MetricsTest, CleanupSuccess)
+{
+  MockMetricsService metricsService;
+
+  process::http::Response response(process::http::Status::ACCEPTED);
+
+  Future<process::http::Request> request;
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(DoAll(FutureArg<0>(&request),
+                    Return(response)));
+
+  const string CONTAINER_ID = "new-container";
+
+  ContainerID containerId;
+  containerId.set_value(CONTAINER_ID);
+
+  Future<Nothing> cleanedup = isolator->cleanup(containerId);
+
+  AWAIT_READY(request);
+
+  ASSERT_EQ(request->method, "DELETE");
+
+  // Verify that the DELETE request is made for a path which reflects the
+  // target container's ID.
+  const vector<string> pathTokens = strings::tokenize(request->url.path, "/");
+
+  ASSERT_EQ(pathTokens.size(), 3);
+  ASSERT_EQ(pathTokens[2], CONTAINER_ID);
+
+  AWAIT_READY(cleanedup);
+}
+
+
+// When the isolator's `cleanup()` method is called and the module receives an
+// unexpected response code from the metrics service, the isolator should return
+// a failed future.
+TEST_F(MetricsTest, CleanupFailureUnexpectedStatusCode)
+{
+  MockMetricsService metricsService;
+
+  process::http::Response response(process::http::Status::OK);
+
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(Return(response));
+
+  const string CONTAINER_ID = "new-container";
+
+  ContainerID containerId;
+  containerId.set_value(CONTAINER_ID);
+
+  Future<Nothing> cleanedup = isolator->cleanup(containerId);
+
+  AWAIT_FAILED(cleanedup);
+}
+
+
+// When the isolator's `recover()` method is called and it finds legacy state
+// on disk, it should make API requests to the metrics service to transfer
+// ownership of the checkpointed container metrics state.
+TEST_F(MetricsTest, RecoverSuccessWithLegacyState)
+{
+  MockMetricsService metricsService;
+
+  const hashmap<string, int> containers =
+    {{"container1", 1234}, {"container2", 5678}};
+
+  LegacyStateStore stateStore(containers, statePath);
+
+  // Check that the container state directory exists. We will confirm that it
+  // has been moved after recovery.
+  ASSERT_TRUE(os::exists(path::join(statePath, "containers")));
+
+  // In the recovery case, the metrics module doesn't use the returned host and
+  // port for anything. We inject some dummy values here to avoid addressing the
+  // fact that the order in which the requests is made is not certain.
+  ContainerStartResponse responseBody;
+  responseBody.set_statsd_host("127.0.0.1");
+  responseBody.set_statsd_port(1234);
+
+  process::http::Response response(
+      string(jsonify(JSON::Protobuf(responseBody))),
+      process::http::Status::CREATED,
+      "application/json");
+
+  Future<process::http::Request> request1;
+  Future<process::http::Request> request2;
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(DoAll(FutureArg<0>(&request1),
+                    Return(response)))
+    .WillOnce(DoAll(FutureArg<0>(&request2),
+                    Return(response)));
+
+  // Construct the agent's recovered state, which is passed
+  // into the module's `recover()` method.
+  vector<mesos::slave::ContainerState> agentState;
+
+  foreachkey (const string& containerId_, containers) {
+    ContainerID containerId;
+    containerId.set_value(containerId_);
+
+    mesos::slave::ContainerState containerState;
+
+    containerState.mutable_container_id()->CopyFrom(containerId);
+    containerState.set_pid(0);
+    containerState.set_directory(os::getcwd());
+
+    agentState.push_back(containerState);
+  }
+
+  Future<Nothing> recovered = isolator->recover(agentState, {});
+
+  // Verify the contents of the module's requests.
+  vector<Future<process::http::Request>> requests{request1, request2};
+  foreach (const Future<process::http::Request>& request, requests) {
+    AWAIT_READY(request);
+
+    Try<ContainerStartRequest> requestBody =
+      parse<ContainerStartRequest>(request->body);
+
+    ASSERT_SOME(requestBody);
+    ASSERT_EQ(request->method, "POST");
+
+    ASSERT_TRUE(requestBody->has_statsd_host());
+    ASSERT_EQ(requestBody->statsd_host(), LEGACY_HOST);
+
+    ASSERT_TRUE(requestBody->has_statsd_port());
+    ASSERT_TRUE(containers.contains(requestBody->container_id()));
+    ASSERT_EQ(
+        requestBody->statsd_port(),
+        containers.at(requestBody->container_id()));
+  }
+
+  AWAIT_READY(recovered);
+
+  ASSERT_FALSE(os::exists(statePath));
+}
+
+
+// When the isolator's `recover()` method is called, the legacy state directory
+// has been set in the module configuration, but the state directory does not
+// exist, then the module should return a ready future.
+TEST_F(MetricsTest, RecoverSuccessWithoutLegacyDirectory)
+{
+  Clock::pause();
+
+  MockMetricsService metricsService;
+
+  os::rm(statePath);
+
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .Times(0);
+
+  vector<mesos::slave::ContainerState> agentState;
+
+  Future<Nothing> recovered = isolator->recover(agentState, {});
+
+  AWAIT_READY(recovered);
+
+  // Settle the clock to ensure that the metrics API is not called.
+  Clock::settle();
+
+  Clock::resume();
+}
+
+
+// When the isolator's `recover()` method is called, the legacy state directory
+// has been set in the module configuration, the state directory exists, no
+// recovered containers are passed to the module, and the state directory is
+// empty as expected, then the module should return a ready future.
+TEST_F(MetricsTest, RecoverSuccessNoLegacyState)
+{
+  MockMetricsService metricsService;
+
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .Times(0);
+
+  vector<mesos::slave::ContainerState> agentState;
+
+  Future<Nothing> recovered = isolator->recover(agentState, {});
+
+  AWAIT_READY(recovered);
+}
+
+
+// When the isolator's `recover()` method is called, the legacy state directory
+// has been set in the module configuration, the state directory exists,
+// recovered containers are passed to the module by the agent, but the state
+// directory is unexpectedly empty, the module should return a failed future.
+TEST_F(MetricsTest, RecoverFailureMissingLegacyState)
+{
+  Clock::pause();
+
+  MockMetricsService metricsService;
+
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .Times(0);
+
+  vector<mesos::slave::ContainerState> agentState;
+
+  ContainerID containerId;
+  containerId.set_value("recovered-container");
+
+  mesos::slave::ContainerState containerState;
+
+  containerState.mutable_container_id()->CopyFrom(containerId);
+  containerState.set_pid(0);
+  containerState.set_directory(os::getcwd());
+
+  agentState.push_back(containerState);
+
+  Future<Nothing> recovered = isolator->recover(agentState, {});
+
+  AWAIT_FAILED(recovered);
+
+  // Settle the clock to ensure that the metrics API is not called.
+  Clock::settle();
+
+  Clock::resume();
+}
+
+
+// When the isolator's `recover()` method is called and it finds legacy state
+// on disk and subsequent requests to the metrics API return an unexpected
+// status code, it should return a failed future.
+TEST_F(MetricsTest, RecoverFailureUnexpectedStatusCode)
+{
+  MockMetricsService metricsService;
+
+  const hashmap<string, int> containers = {{"container1", 1234}};
+
+  LegacyStateStore stateStore(containers, statePath);
+
+  // Check that the container state directory exists. We will confirm that it
+  // still exists after recovery fails.
+  ASSERT_TRUE(os::exists(path::join(statePath, "containers")));
+
+  process::http::Response response(process::http::Status::OK);
+
+  ContainerStartResponse responseBody;
+  response.body = string(jsonify(JSON::Protobuf(responseBody)));
+
+  Future<process::http::Request> request;
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(DoAll(FutureArg<0>(&request),
+                    Return(response)));
+
+  // Construct the agent's recovered state, which is passed
+  // into the module's `recover()` method.
+  vector<mesos::slave::ContainerState> agentState;
+
+  foreachkey (const string& containerId_, containers) {
+    ContainerID containerId;
+    containerId.set_value(containerId_);
+
+    mesos::slave::ContainerState containerState;
+
+    containerState.mutable_container_id()->CopyFrom(containerId);
+    containerState.set_pid(0);
+    containerState.set_directory(os::getcwd());
+
+    agentState.push_back(containerState);
+  }
+
+  Future<Nothing> recovered = isolator->recover(agentState, {});
+
+  AWAIT_FAILED(recovered);
+
+  ASSERT_TRUE(os::exists(path::join(statePath, "containers")));
+}
+
+
+// When the isolator's `prepare()` method is called and the metrics service
+// returns a 409 CONFLICT response, the isolator should return a failed future
+// with an error message that notifies the operator that the recovered port is
+// not available.
+TEST_F(MetricsTest, RecoverFailurePortNotAvailable)
+{
+  MockMetricsService metricsService;
+
+  const int port = 1234;
+  const hashmap<string, int> containers = {{"container1", port}};
+
+  LegacyStateStore stateStore(containers, statePath);
+
+  // Check that the container state directory exists. We will confirm that it
+  // still exists after recovery fails.
+  ASSERT_TRUE(os::exists(path::join(statePath, "containers")));
+
+  process::http::Response response(process::http::Status::CONFLICT);
+
+  Future<process::http::Request> request;
+  EXPECT_CALL(*metricsService.mock, container(_))
+    .WillOnce(DoAll(FutureArg<0>(&request),
+                    Return(response)));
+
+  // Construct the agent's recovered state, which is passed
+  // into the module's `recover()` method.
+  vector<mesos::slave::ContainerState> agentState;
+
+  foreachkey (const string& containerId_, containers) {
+    ContainerID containerId;
+    containerId.set_value(containerId_);
+
+    mesos::slave::ContainerState containerState;
+
+    containerState.mutable_container_id()->CopyFrom(containerId);
+    containerState.set_pid(0);
+    containerState.set_directory(os::getcwd());
+
+    agentState.push_back(containerState);
+  }
+
+  Future<Nothing> recovered = isolator->recover(agentState, {});
+
+  AWAIT_FAILED(recovered);
+
+  ASSERT_TRUE(strings::contains(recovered.failure(), stringify(port)));
+
+  ASSERT_TRUE(os::exists(path::join(statePath, "containers")));
+}
+
+} // namespace tests {
+} // namespace metrics {
+} // namespace mesos {


### PR DESCRIPTION
This PR adds the new metrics isolator module. The module does the following:
* Hits the metrics service API during container launch to retrieve a metrics host/port
* Injects the retrieved host/port into the container's environment