### PR TITLE
fixes iptables rules to support coreos 1800.7.0

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -933,14 +933,21 @@ Future<Nothing> ManagerProcess::__configureDockerNetwork(
   // However, Docker disallows this. So we will install a de-funct
   // rule in the DOCKER-ISOLATION chain to bypass any isolation
   // docker might be trying to enforce.
-  const string iptablesCommand = "iptables -w -D DOCKER-ISOLATION -j RETURN; "
-    "iptables -w -I DOCKER-ISOLATION 1 -j RETURN";
+  const string iptablesCommand = 
+      "iptables -w -D DOCKER-ISOLATION -j RETURN; "
+      "iptables -w -I DOCKER-ISOLATION 1 -j RETURN";
 
   Duration timeout = Milliseconds(networkConfig.command_timeout());
   return runScriptCommand(iptablesCommand, timeout)
-    .then([]() -> Future<Nothing> {
-        return Nothing();
-        });
+      .repair(defer(self(), [timeout](const Future<string>&) {
+          const string iptablesCommand =     
+              "iptables -w -D DOCKER-ISOLATION-STAGE-2 -j RETURN; "
+              "iptables -w -I DOCKER-ISOLATION-STAGE-2 1 -j RETURN";
+          return runScriptCommand(iptablesCommand, timeout);
+      }))
+      .then([]() -> Future<Nothing> {
+          return Nothing();
+      });
 }
 
 ManagerProcess::ManagerProcess(

--- a/tests/overlay_tests.cpp
+++ b/tests/overlay_tests.cpp
@@ -203,8 +203,8 @@ protected:
         "iptables -w -t nat -D POSTROUTING -s %s "
         "-m set --match-set %s dst "
         "-j MASQUERADE; "
-        "iptables -w -t filter -D DOCKER-ISOLATION "
-        "-j RETURN; "
+        "iptables -w -t filter -D DOCKER-ISOLATION -j RETURN; "
+        "iptables -w -t filter -D DOCKER-ISOLATION-STAGE-2 -j RETURN; "
         "ipset destroy %s; "
         "docker network rm %s %s",
         OVERLAY_SUBNET,
@@ -1786,10 +1786,24 @@ TEST_F(OverlayTest, ROOT_checkDockerIsolation)
   // Check the agent is allowed to progress.
   AWAIT_READY(agentModule.get()->ready());
 
-  // Verify the Docker isolation bypass iptable rule
+  std::string dockerChain = "DOCKER-ISOLATION";
+
+  // Check the docker chain
   Future<string> iptables = runCommand("iptables",
       {"iptables", "-w",
-       "-C", "DOCKER-ISOLATION",
+       "-L", dockerChain
+      });
+
+  iptables.await();
+
+  if (iptables.isFailed()) {
+      dockerChain = "DOCKER-ISOLATION-STAGE-2";
+  }
+
+  // Verify the Docker isolation bypass iptable rule
+  iptables = runCommand("iptables",
+      {"iptables", "-w",
+       "-C", dockerChain,
        "-j", "RETURN"
       });
 
@@ -1798,7 +1812,7 @@ TEST_F(OverlayTest, ROOT_checkDockerIsolation)
   // Verify that iptables rule is the first one in the chain
   iptables = runCommand("iptables",
       {"iptables", "-w",
-       "-D", "DOCKER-ISOLATION",
+       "-D", dockerChain,
        "1"});
 
   AWAIT_READY(iptables);


### PR DESCRIPTION
Coreos 1800.7.0 comes with default docker version of 18.x which has modified its iptables CHAIN names from `DOCKER-ISOLATION` to `DOCKER-ISOLATION-STAGE-1` and `DOCKER-ISOLATION-STAGE-2` which broke mesos overlay module. This patch detects the CHAIN name before applying the iptables rule so that it could work for both old and newer docker versions.

jira: https://jira.mesosphere.com/browse/DCOS_OSS-3707