### PR TITLE
[Backport] [1.11] fixes iptables rules to support coreos 1800.7.0

### DIFF
--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -908,13 +908,20 @@ Future<Nothing> ManagerProcess::__configureDockerNetwork(
   // However, Docker disallows this. So we will install a de-funct
   // rule in the DOCKER-ISOLATION chain to bypass any isolation
   // docker might be trying to enforce.
-  const string iptablesCommand = "iptables -w -D DOCKER-ISOLATION -j RETURN; "
-    "iptables -w -I DOCKER-ISOLATION 1 -j RETURN";
+  const string iptablesCommand = 
+      "iptables -w -D DOCKER-ISOLATION -j RETURN; "
+      "iptables -w -I DOCKER-ISOLATION 1 -j RETURN";
 
   return runScriptCommand(iptablesCommand)
-    .then([]() -> Future<Nothing> {
-        return Nothing();
-        });
+      .repair(defer(self(), [](const Future<string>&) {
+          const string iptablesCommand =     
+              "iptables -w -D DOCKER-ISOLATION-STAGE-2 -j RETURN; "
+              "iptables -w -I DOCKER-ISOLATION-STAGE-2 1 -j RETURN";
+          return runScriptCommand(iptablesCommand);
+      }))
+      .then([]() -> Future<Nothing> {
+          return Nothing();
+      });
 }
 
 ManagerProcess::ManagerProcess(

--- a/overlay/agent.cpp
+++ b/overlay/agent.cpp
@@ -626,9 +626,9 @@ Future<Nothing> ManagerProcess::_configure(
 
       command = strings::format(
           "ipset add -exist %s %s" " nomatch &&"
-          " iptables -t nat -C POSTROUTING -s %s -m set"
+          " iptables -w -t nat -C POSTROUTING -s %s -m set"
           " --match-set %s dst -j MASQUERADE ||"
-          " iptables -t nat -A POSTROUTING -s %s -m"
+          " iptables -w -t nat -A POSTROUTING -s %s -m"
           " set --match-set %s dst -j MASQUERADE",
           IPSET_OVERLAY,
           overlaySubnet,
@@ -908,8 +908,8 @@ Future<Nothing> ManagerProcess::__configureDockerNetwork(
   // However, Docker disallows this. So we will install a de-funct
   // rule in the DOCKER-ISOLATION chain to bypass any isolation
   // docker might be trying to enforce.
-  const string iptablesCommand = "iptables -D DOCKER-ISOLATION -j RETURN; "
-    "iptables -I DOCKER-ISOLATION 1 -j RETURN";
+  const string iptablesCommand = "iptables -w -D DOCKER-ISOLATION -j RETURN; "
+    "iptables -w -I DOCKER-ISOLATION 1 -j RETURN";
 
   return runScriptCommand(iptablesCommand)
     .then([]() -> Future<Nothing> {

--- a/tests/overlay_tests.cpp
+++ b/tests/overlay_tests.cpp
@@ -200,10 +200,10 @@ protected:
     // We don't need to worry about whether the commands were
     // successful since this is precautionary.
     Try<string> cleanup = strings::format(
-        "iptables -t nat -D POSTROUTING -s %s "
+        "iptables -w -t nat -D POSTROUTING -s %s "
         "-m set --match-set %s dst "
         "-j MASQUERADE; "
-        "iptables -t filter -D DOCKER-ISOLATION "
+        "iptables -w -t filter -D DOCKER-ISOLATION "
         "-j RETURN; "
         "ipset destroy %s; "
         "docker network rm %s %s",
@@ -244,7 +244,7 @@ protected:
               masterOverlayConfig.network().overlays()) {
         Future<string> iptables = runCommand(
             "iptables",
-            {"iptables",
+            {"iptables", "-w",
             "-t", "nat",
             "-D", "POSTROUTING",
             "-s", overlay.subnet(),
@@ -272,7 +272,9 @@ protected:
            "rm",
            OVERLAY_NAME, 
            OVERLAY_NAME_2});
-      AWAIT_READY(docker);
+      // cannot use AWAIT_READY as it would fail if one of the networks
+      // is absent
+      docker.await();
     }
 
     MesosTest::TearDown();
@@ -586,7 +588,7 @@ TEST_F(OverlayTest, ROOT_checkMesosNetwork)
 
   // Verify that the `IPMASQ` rules have been installed.
   Future<string> iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
       "-t", "nat",
       "-C", "POSTROUTING",
       "-s", OVERLAY_SUBNET,
@@ -680,7 +682,7 @@ TEST_F(OverlayTest, ROOT_checkDockerNetwork)
 
   // Verify that the `IPMASQ` rules have been installed.
   Future<string> iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
       "-t", "nat",
       "-C", "POSTROUTING",
       "-s", OVERLAY_SUBNET,
@@ -1100,7 +1102,7 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
 
   // Verify that the `IPMASQ` rules have been installed.
   Future<string> iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
       "-t", "nat",
       "-C", "POSTROUTING",
       "-s", OVERLAY_SUBNET,
@@ -1113,7 +1115,7 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
 
   // Delete the IPMASQ rules.
   iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
       "-t", "nat",
       "-D", "POSTROUTING",
       "-s", OVERLAY_SUBNET,
@@ -1145,7 +1147,7 @@ TEST_F(OverlayTest, ROOT_checkAgentNetworkConfigChange)
   // With the `mesos_bridge` and the `docker_bridge` disabled there
   // should be no IPMASQ rules installed. Check IPMASQ rules don't exist.
   iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
       "-t", "nat",
       "-C", "POSTROUTING",
       "-s", OVERLAY_SUBNET,
@@ -1641,7 +1643,7 @@ TEST_F(OverlayTest, ROOT_checkDockerIsolation)
 
   // Verify the Docker isolation bypass iptable rule
   Future<string> iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
        "-C", "DOCKER-ISOLATION",
        "-j", "RETURN"
       });
@@ -1650,7 +1652,7 @@ TEST_F(OverlayTest, ROOT_checkDockerIsolation)
 
   // Verify that iptables rule is the first one in the chain
   iptables = runCommand("iptables",
-      {"iptables",
+      {"iptables", "-w",
        "-D", "DOCKER-ISOLATION",
        "1"});
 


### PR DESCRIPTION
Coreos 1800.7.0 comes with default docker version of 18.x which has modified its iptables CHAIN names from DOCKER-ISOLATION to DOCKER-ISOLATION-STAGE-1 and DOCKER-ISOLATION-STAGE-2 which broke mesos overlay module. This patch detects the CHAIN name before applying the iptables rule so that it could work for both old and newer docker versions.

jira: https://jira.mesosphere.com/browse/DCOS_OSS-3707