### PR TITLE
[1.12][Backport] Fixed the module build failure by adding 'using std::array'.

### DIFF
--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <map>
 #include <string>
 #include <vector>
@@ -34,6 +35,7 @@
 using namespace mesos;
 using namespace process;
 
+using std::array;
 using std::string;
 using std::vector;
 


### PR DESCRIPTION
(cherry picked from commit 72c10ca6eaaee74fa5a6ac62102be62442145ba3)