### PR TITLE
Backport fixes for the metrics isolator.

### DIFF
--- a/metrics/isolator.cpp
+++ b/metrics/isolator.cpp
@@ -214,7 +214,7 @@ public:
           [=](const Future<Future<http::Response>>& response) {
             if (!response->isReady()) {
               LOG(ERROR)
-                << "Failed posting container DELETE request for"
+                << "Failed sending container DELETE request for"
                 << " container '" << containerId.value() << "': "
                 << (response->isFailed() ?
                       response->failure() : "Future discarded");
@@ -222,7 +222,7 @@ public:
               LOG(ERROR)
                 << "Received unexpected response code"
                 << " '" << stringify(response.get()->code) << "' when"
-                << " posting 'ContainerStartRequest' for container"
+                << " sending DELETE request for container"
                 << " '" << containerId.value() << "'";
             }
 

--- a/metrics/messages.proto
+++ b/metrics/messages.proto
@@ -17,11 +17,3 @@ message ContainerStartResponse {
   optional string statsd_host = 1;
   optional int32 statsd_port = 2;
 }
-
-message ContainerStopRequest {
-  // The ContainerID of the container to
-  // stop listening for metrics from.
-  required string container_id = 1;
-}
-
-message ContainerStopResponse {}


### PR DESCRIPTION
This PR backports to 1.12 several fixes for the metrics isolator module to which have already landed in the master branch. See https://github.com/dcos/dcos-mesos-modules/pull/57