### PR TITLE
Add additional log output to 'ROOT_LogToJournald' test.

### DIFF
--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -653,7 +653,8 @@ TEST_P(JournaldLoggerTest, ROOT_LogToJournald)
 
     Result<std::string> stdout = os::read(stdoutPath);
     ASSERT_SOME(stdout);
-    EXPECT_FALSE(strings::contains(stdout.get(), specialString));
+    EXPECT_FALSE(strings::contains(stdout.get(), specialString))
+      << "Expected " << specialString << " to appear in " << stdout.get();
   }
 
   if (GetParam() == "logrotate" ||


### PR DESCRIPTION
This test was observed to be flaky, and this information
might be helpful to narrow down the root cause of the
flakiness.