### PR TITLE
Add additional log output to 'ROOT_LogToJournald' test.

### DIFF
--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -654,7 +654,7 @@ TEST_P(JournaldLoggerTest, ROOT_LogToJournald)
     Result<std::string> stdout = os::read(stdoutPath);
     ASSERT_SOME(stdout);
     EXPECT_FALSE(strings::contains(stdout.get(), specialString))
-      << "Expected " << specialString << " to appear in " << stdout.get();
+      << "Not expected " << specialString << " to appear in " << stdout.get();
   }
 
   if (GetParam() == "logrotate" ||
@@ -664,7 +664,8 @@ TEST_P(JournaldLoggerTest, ROOT_LogToJournald)
 
     Result<std::string> stdout = os::read(stdoutPath);
     ASSERT_SOME(stdout);
-    EXPECT_TRUE(strings::contains(stdout.get(), specialString));
+    EXPECT_TRUE(strings::contains(stdout.get(), specialString))
+      << "Expected " << specialString << " to appear in " << stdout.get();
   }
 }
 


### PR DESCRIPTION
## High-level description

This is an addendum to https://github.com/dcos/dcos-mesos-modules/pull/81

Both `logrotate` and `journald+logrotate` flavours of this test are flaky, this
extra information will be helpful for triaging. For more information, see
https://jira.mesosphere.com/browse/DCOS-46137

A logging change, does not need to be reflected in the CHANGELOG.