### PR TITLE
Add additional log output to 'ROOT_LogToJournald' test.

### DIFF
--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -643,7 +643,8 @@ TEST_P(JournaldLoggerTest, ROOT_LogToJournald)
       "latest");
   ASSERT_TRUE(os::exists(sandboxDirectory));
 
-  std::string stdoutPath = path::join(sandboxDirectory, "stdout");
+  const std::string stdoutPath = path::join(sandboxDirectory, "stdout");
+  const std::string stderrPath = path::join(sandboxDirectory, "stderr");
 
   if (GetParam() == "journald") {
     // Check that the sandbox was *not* written to.
@@ -661,11 +662,17 @@ TEST_P(JournaldLoggerTest, ROOT_LogToJournald)
       GetParam() == "journald+logrotate") {
     // Check that the sandbox was written to as well.
     ASSERT_TRUE(os::exists(stdoutPath));
+    ASSERT_TRUE(os::exists(stderrPath));
 
     Result<std::string> stdout = os::read(stdoutPath);
     ASSERT_SOME(stdout);
+
+    Result<std::string> stderr = os::read(stderrPath);
+    ASSERT_SOME(stderr);
+
     EXPECT_TRUE(strings::contains(stdout.get(), specialString))
-      << "Expected " << specialString << " to appear in " << stdout.get();
+      << "Expected " << specialString << " to appear in " << stdout.get() << ";"
+      << " stderr: " << stderr.get();
   }
 }
 


### PR DESCRIPTION
## High-level description

This is an addendum to https://github.com/dcos/dcos-mesos-modules/pull/90

Both `logrotate` and `journald+logrotate` flavours of this test are flaky:
stdout of the task is sometimes empty. Being able to look at stderr as well
will be helpful for triaging. For more information, see DCOS-46137.

## Corresponding DC/OS or Apache Mesos tickets (obligatory)

Nada, a minor update to the test code.