### PR TITLE
Master overlay module got stuck in RECOVERING state

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,13 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.synced_folder "..", "/work", type: "virtualbox"
 
   config.vm.provider "virtualbox" do |v|
     v.linked_clone = true
-    v.memory = 4096
+    v.memory = 8192
     v.cpus = 4
   end
 
@@ -16,7 +16,8 @@ Vagrant.configure(2) do |config|
     sudo apt-get update
 
     sudo apt-get install -y \
-        gcc- g++- g++-*- clang \
+        clang lld \
+        clang-format clang-tidy clang-tools \
         tar wget git \
         openjdk-8-jdk \
         autoconf libtool \

--- a/overlay/master.cpp
+++ b/overlay/master.cpp
@@ -1942,6 +1942,8 @@ private:
 
   void demote()
   {
+    LOG(WARNING) << "Demoting " << self();
+
     // Reset state of the replicated log.
     recovering = false;
     storing = false;

--- a/overlay/master.cpp
+++ b/overlay/master.cpp
@@ -1584,6 +1584,7 @@ protected:
                    <<(variable.isDiscarded() ? "discarded"
                        : variable.failure());
 
+      demote();
       return;
     }
 

--- a/overlay/master.cpp
+++ b/overlay/master.cpp
@@ -1748,6 +1748,7 @@ protected:
     storedState = variable.get();
 
     LOG(INFO) << "Moving " << self() << " to `RECOVERED` state.";
+    recovering = false;
     return;
   }
 

--- a/overlay/master.cpp
+++ b/overlay/master.cpp
@@ -1605,7 +1605,8 @@ protected:
       Try<Agent> agent = Agent::create(agentInfo);
       if (agent.isError()) {
         LOG(ERROR) << "Could not recover Agent: "<< agent.error();
-        abort();
+        demote();
+        return;
       }
 
       agents.emplace(agent->getIP(), agent.get());
@@ -1628,7 +1629,8 @@ protected:
                        << overlay.subnet() << ": "
                        << network.error();
 
-            abort();
+            demote();
+            return;
           }
 
           // We should already have this particular overlay at bootup.
@@ -1641,7 +1643,8 @@ protected:
             LOG(ERROR) << "Unable to reserve the subnet " << network.get()
                        << ": " << result.error();
 
-            abort();
+            demote();
+            return;
           }
         }
 
@@ -1655,7 +1658,8 @@ protected:
             LOG(ERROR) << "Unable to parse the retrieved network: "
               << overlay.subnet6() << ": "
               << network6.error();
-            abort();
+            demote();
+            return;
           }
 
           // We should already have this particular overlay at bootup.
@@ -1667,7 +1671,8 @@ protected:
           if (result.isError()) {
             LOG(ERROR) << "Unable to reserve the IPv6 subnet " << network6.get()
                        << ": " << result.error();
-            abort();
+            demote();
+            return;
           }
         }
 
@@ -1684,7 +1689,8 @@ protected:
                        << overlay.backend().vxlan().vtep_ip() << ": "
                        << vtepIP.error();
 
-            abort();
+            demote();
+            return;
           }
 
           // NOTE: We only need to reserve the VTEP IP and not the
@@ -1697,7 +1703,8 @@ protected:
             LOG(ERROR) << "Unable to reserve VTEP IP: "
                        << vtepIP.get() << ": " << result.error();
 
-            abort();
+            demote();
+            return;
           }
 
           // IPv6
@@ -1709,7 +1716,8 @@ protected:
               LOG(ERROR) << "Unable to parse the retrieved `vtep IPv6`: "
                 << overlay.backend().vxlan().vtep_ip6() << ": "
                 << vtepIP6.error();
-              abort();
+              demote();
+              return;
             }
 
             LOG(INFO) << "Reserving VTEP IPv6: " << vtepIP6.get();
@@ -1717,7 +1725,8 @@ protected:
             if (result.isError()) {
               LOG(ERROR) << "Unable to reserve VTEP IPv6: "
                          << vtepIP6.get() << ": " << result.error();
-              abort();
+              demote();
+              return;
             }
           }
         }

--- a/overlay/supervisor.hpp
+++ b/overlay/supervisor.hpp
@@ -1,0 +1,140 @@
+#ifndef __SUPERVISOR_OVERLAY_HPP__
+#define __SUPERVISOR_OVERLAY_HPP__
+
+#include <queue>
+
+#include <stout/duration.hpp>
+#include <stout/lambda.hpp>
+#include <stout/try.hpp>
+
+#include <process/delay.hpp>
+#include <process/owned.hpp>
+#include <process/process.hpp>
+
+namespace mesos {
+namespace modules {
+namespace overlay {
+namespace supervisor {
+
+template <typename T>
+class ProcessSupervisor : public process::Process<ProcessSupervisor<T>>
+{
+public:
+  typedef lambda::function<Try<process::Owned<T>>()> Func;
+
+  static Try<process::Owned<ProcessSupervisor<T>>> create(
+      const Func& func,
+      const Duration& delay)
+  {
+    Try<process::Owned<T>> result = func();
+    if (result.isError()) {
+      LOG(ERROR) << "Unable to create the process: " << result.error();
+      return Error(result.error());
+    }
+
+    return process::Owned<ProcessSupervisor<T>>(
+      new ProcessSupervisor(result.get(), func, delay));
+  }
+
+  ~ProcessSupervisor()
+  {
+    LOG(INFO) << "Terminating the child process.";
+    state = State::TERMINATING;
+    if (process.get() != nullptr) {
+      terminate(process.get());
+      wait(process.get());
+      process.reset();
+    }
+  }
+
+  const process::Future<process::UPID> child()
+  {
+    if (process.get() != nullptr && state == State::SPAWNED) {
+      return process->self();
+    } else {
+      process::Promise<process::UPID> *promise =
+        new process::Promise<process::UPID>();
+      promises.push(promise);
+      return promise->future();
+    }
+  }
+
+protected:
+  // Because we're deriving from a templated base class, we have
+  // to explicitly bring these hidden base class names into scope.
+  using process::Process<ProcessSupervisor<T>>::self;
+  using process::Process<ProcessSupervisor<T>>::link;
+  typedef ProcessSupervisor<T> Self;
+
+  virtual void initialize() override
+  {
+    LOG(INFO) << "(Re-)starting the process";
+
+    if (process.get() == nullptr) {
+        Try<process::Owned<T>> result = func();
+        if (result.isError()) {
+          LOG(ERROR) << "Unable to create the process: " << result.error();
+          process::delay(delay, self(), &Self::initialize);
+          return;
+        }
+        state = State::UNSPAWNED;
+        process = result.get();
+    }
+
+    spawn(process.get());
+    state = State::SPAWNED;
+
+    LOG(INFO) << "Linking the process: " << process->self();
+    link(process->self());
+
+    while (!promises.empty()) {
+      process::Promise<process::UPID>* promise = promises.front();
+      promise->set(process->self());
+      delete promise;
+      promises.pop();
+    }
+  }
+
+  virtual void exited(const process::UPID& pid) override
+  {
+    LOG(WARNING) << "The process has exited: " << pid;
+
+    if (state != State::TERMINATING) {
+      state = State::TERMINATING;
+      process.reset();
+
+      // Re-start the process with delay.
+      process::delay(delay, self(), &Self::initialize);
+    }
+  }
+
+private:
+  enum class State
+  {
+    UNSPAWNED,
+    SPAWNED,
+    TERMINATING
+  };
+
+  ProcessSupervisor(
+    process::Owned<T> _process,
+    const Func& _func,
+    const Duration& _delay)
+    : func(_func),
+      delay(_delay),
+      process(_process),
+      state(State::UNSPAWNED) {}
+
+  const Func func;
+  const Duration delay;
+  process::Owned<T> process;
+  std::queue<process::Promise<process::UPID>*> promises;
+  State state;
+};
+
+} // namespace supervisor {
+} // namespace overlay {
+} // namespace modules {
+} // namespace mesos {
+
+#endif // __SUPERVISOR_OVERLAY_HPP__


### PR DESCRIPTION
## High-level description

There are multiple issues with recovering mode in master overlay module.

1. There are no timeouts in any replicated log functions. I added timeout for `fetch()`in #82, but master modules still will get stuck if replicated log times out.

2. There are a bunch of `abort()` calls in `_recover()` function. It means that module can kill the whole mesos leader. Recently, we've seen mesos leader crash looping because of it.

3. `demote()` doesn't force agent re-registration or mesos re-election.

## Corresponding DC/OS or Apache Mesos tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4575](https://jira.mesosphere.com/browse/DCOS_OSS-4575) Add timeout while trying to recover overlay