### PR TITLE
Added a comment around synchronization on container cleanup.

### DIFF
--- a/journald/lib_journald.hpp
+++ b/journald/lib_journald.hpp
@@ -230,6 +230,10 @@ struct Flags : public virtual LoggerFlags
 // Logging to sandbox is approximately equivalent to using the
 // `LogrotateContainerLogger`, packaged with vanilla Mesos.
 // See `Flags` above.
+//
+// NOTE: The lack of `ContainerLogger::cleanup()` or similar prevents
+// synchronization on container termination, i.e., a terminal status update for
+// a container can be sent before logs are flushed.
 class JournaldContainerLogger : public mesos::slave::ContainerLogger
 {
 public:


### PR DESCRIPTION
## High-level description

`ContainerLogger` interface does not currently use a
"prepare-recover-cleanup" pattern and hence neither allows
stateful loggers nor provides synchronization on container
termination.
