### PR TITLE
Journald logrotate configuration file sealing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,10 @@ mesos_journald_logger_SOURCES =				\
 
 SYSTEMD_JOURNALD = `pkg-config --cflags --libs libsystemd`
 
+# NOTE: The modules build assumes that Mesos is built with
+# `--enable-launcher-sealing` and `--disable-libtool-wrappers`.
+# An internal symbol gated by this flag inside `src/linux/memfd.hpp`
+# will be used by the logger.
 mesos_journald_logger_LDFLAGS =				\
   $(MESOS_LDFLAGS)					\
   $(SYSTEMD_JOURNALD)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd <mesos-source>
 ./bootstrap
 mkdir build
 cd build
-../configure --enable-libevent --enable-ssl --enable-install-module-dependencies
+../configure --enable-libevent --enable-ssl --enable-install-module-dependencies --enable-launcher-sealing --disable-libtool-wrappers
 make
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -182,7 +182,7 @@ if test -n "`echo $with_protobuf`"; then
 else
   if test -d "$mesos_build_dir"; then
     # Check for the protobuf compiler in 3rdparty PATH.
-    AC_PATH_TOOL([PROTOCOMPILER], [protoc], [], [${mesos_build_dir}/3rdparty/bin])
+    AC_PATH_TOOL([PROTOCOMPILER], [protoc], [], [${mesos_build_dir}/3rdparty/protobuf-3.5.0/src])
   else
     # Check for the protobuf compiler in default PATH.
     AC_PATH_TOOL([PROTOCOMPILER], [protoc], [], [$PATH])

--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -107,9 +107,7 @@ public:
     LoggerFlags overriddenFlags;
     overriddenFlags.destination_type = flags.destination_type;
     overriddenFlags.logrotate_max_stdout_size = flags.logrotate_max_stdout_size;
-    overriddenFlags.logrotate_stdout_options = flags.logrotate_stdout_options;
     overriddenFlags.logrotate_max_stderr_size = flags.logrotate_max_stderr_size;
-    overriddenFlags.logrotate_stderr_options = flags.logrotate_stderr_options;
 
     // TODO(jieyu): Consider merge labels with container specific
     // extra labels from the environment, instead of overwriting.
@@ -146,6 +144,15 @@ public:
         LOG(WARNING) << warning.message;
       }
     }
+
+    // TODO(josephw): Custom options would allow tasks to execute arbitrary
+    // scripts in logrotate's `postrotate` clause or add rotation of arbitrary
+    // files.  This is disabled in favor of more targeted options in future,
+    // such as ints for the number of files to keep, or bools for compression.
+    // See: https://issues.apache.org/jira/browse/MESOS-9564
+    // and https://jira.mesosphere.com/browse/DCOS-47733.
+    overriddenFlags.logrotate_stdout_options = flags.logrotate_stdout_options;
+    overriddenFlags.logrotate_stderr_options = flags.logrotate_stderr_options;
 
     Option<ExecutorInfo> executorInfo;
     if (containerConfig.has_executor_info()) {

--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -166,7 +166,7 @@ public:
     MesosTest::TearDown();
   }
 
-private:
+protected:
   Modules modules;
 };
 
@@ -307,6 +307,32 @@ TEST_F(JournaldLoggerTest, ROOT_LogToJournaldWithBigLabel)
 // non-existence of the logrotate config file.
 TEST_F(JournaldLoggerTest, ROOT_LogrotateCustomOptions)
 {
+  const std::string testFile = path::join(sandbox.get(), "CustomRotateOptions");
+
+  // Custom config consists of a postrotate script which creates
+  // an empty file in the temporary directory on log rotation.
+  const std::string customConfig =
+    "postrotate\n touch " + testFile + "\nendscript";
+
+  // There is no way to change a task's custom logrotate options except when
+  // loading the module.  So this test will unload the module, change the
+  // logrotate options, and then reload the module.
+  ASSERT_SOME(ModuleManager::unload(JOURNALD_LOGGER_NAME));
+
+  foreach (Modules::Library& library, *modules.mutable_libraries()) {
+    foreach (Modules::Library::Module& module, *library.mutable_modules()) {
+      if (module.has_name() && module.name() == JOURNALD_LOGGER_NAME) {
+        Parameter* parameter = module.add_parameters();
+        parameter->set_key("logrotate_stdout_options");
+        parameter->set_value(customConfig);
+      }
+    }
+  }
+
+  // Initialize the modules.
+  Try<Nothing> result = ModuleManager::load(modules);
+  ASSERT_SOME(result);
+
   // Create a master, agent, and framework.
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
@@ -352,13 +378,6 @@ TEST_F(JournaldLoggerTest, ROOT_LogrotateCustomOptions)
   AWAIT_READY(offers);
   EXPECT_NE(0u, offers.get().size());
 
-  const std::string testFile = path::join(sandbox.get(), "CustomRotateOptions");
-
-  // Custom config consists of a postrotate script which creates
-  // an empty file in the temporary directory on log rotation.
-  const std::string customConfig =
-    "postrotate\n touch " + testFile + "\nendscript";
-
   // Start a task that spams stdout with 2 MB of (mostly blank) output.
   // The container logger module is loaded with parameters that limit
   // the log size to files of 10 MB each.  After the task completes,
@@ -376,10 +395,18 @@ TEST_F(JournaldLoggerTest, ROOT_LogrotateCustomOptions)
   variable->set_value("logrotate");
 
   // Add an override for the logger's stdout stream.
-  // We will check this by inspecting the generated configuration file.
+  // This way of overriding custom options should be disabled,
+  // so we will check that these options are ignored.
+  // See MESOS-9564 for more context.
+  const std::string ignoredtestFile =
+    path::join(sandbox.get(), "ShouldNotBeCreated");
+
+  const std::string ignoredConfig =
+    "postrotate\n touch " + ignoredtestFile + "\nendscript";
+
   variable = task.mutable_command()->mutable_environment()->add_variables();
   variable->set_name("CONTAINER_LOGGER_LOGROTATE_STDOUT_OPTIONS");
-  variable->set_value(customConfig);
+  variable->set_value(ignoredConfig);
 
   Future<TaskStatus> statusStarting;
   Future<TaskStatus> statusRunning;
@@ -455,6 +482,7 @@ TEST_F(JournaldLoggerTest, ROOT_LogrotateCustomOptions)
   // Since some logs should have been rotated, the postrotate script should
   // have created this file.
   ASSERT_TRUE(os::exists(testFile));
+  ASSERT_FALSE(os::exists(ignoredtestFile));
 }
 
 

--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -30,6 +30,7 @@
 #include <stout/strings.hpp>
 #include <stout/try.hpp>
 
+#include <stout/os/pstree.hpp>
 #include <stout/os/read.hpp>
 
 #include "common/shell.hpp"
@@ -299,6 +300,161 @@ TEST_F(JournaldLoggerTest, ROOT_LogToJournaldWithBigLabel)
 
   AWAIT_READY(secondQuery);
   ASSERT_FALSE(strings::contains(secondQuery.get(), specialString));
+}
+
+
+// Loads the journald ContainerLogger module and checks for the
+// non-existence of the logrotate config file.
+TEST_F(JournaldLoggerTest, ROOT_LogrotateCustomOptions)
+{
+  // Create a master, agent, and framework.
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+
+  // We'll need access to these flags later.
+  mesos::internal::slave::Flags flags = CreateSlaveFlags();
+
+  // Use the journald container logger.
+  flags.container_logger = JOURNALD_LOGGER_NAME;
+
+  Fetcher fetcher(flags);
+
+  // We use an actual containerizer + executor since we want something to run.
+  Try<MesosContainerizer*> _containerizer =
+    MesosContainerizer::create(flags, false, &fetcher);
+
+  CHECK_SOME(_containerizer);
+  Owned<MesosContainerizer> containerizer(_containerizer.get());
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+
+  Try<Owned<cluster::Slave>> slave =
+    StartSlave(detector.get(), containerizer.get(), flags);
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  Future<FrameworkID> frameworkId;
+  EXPECT_CALL(sched, registered(&driver, _, _))
+    .WillOnce(FutureArg<1>(&frameworkId));
+
+  // Wait for an offer, and start a task.
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+  AWAIT_READY(frameworkId);
+
+  AWAIT_READY(offers);
+  EXPECT_NE(0u, offers.get().size());
+
+  const std::string testFile = path::join(sandbox.get(), "CustomRotateOptions");
+
+  // Custom config consists of a postrotate script which creates
+  // an empty file in the temporary directory on log rotation.
+  const std::string customConfig =
+    "postrotate\n touch " + testFile + "\nendscript";
+
+  // Start a task that spams stdout with 2 MB of (mostly blank) output.
+  // The container logger module is loaded with parameters that limit
+  // the log size to files of 10 MB each.  After the task completes,
+  // `logrotate` should trigger rotation of stdout logs, so the postrotate
+  // script is executed.
+  TaskInfo task = createTask(
+      offers.get()[0],
+      "i=0; while [ $i -lt 10240 ]; "
+      "do printf '%-1024d\\n' $i; i=$((i+1)); done");
+
+  // Make sure the destination of the logs is logrotate.
+  Environment::Variable* variable =
+    task.mutable_command()->mutable_environment()->add_variables();
+  variable->set_name("CONTAINER_LOGGER_DESTINATION_TYPE");
+  variable->set_value("logrotate");
+
+  // Add an override for the logger's stdout stream.
+  // We will check this by inspecting the generated configuration file.
+  variable = task.mutable_command()->mutable_environment()->add_variables();
+  variable->set_name("CONTAINER_LOGGER_LOGROTATE_STDOUT_OPTIONS");
+  variable->set_value(customConfig);
+
+  Future<TaskStatus> statusStarting;
+  Future<TaskStatus> statusRunning;
+  Future<TaskStatus> statusFinished;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&statusStarting))
+    .WillOnce(FutureArg<1>(&statusRunning))
+    .WillOnce(FutureArg<1>(&statusFinished))
+    .WillRepeatedly(Return());       // Ignore subsequent updates.
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(statusStarting);
+  EXPECT_EQ(TASK_STARTING, statusStarting.get().state());
+
+  AWAIT_READY(statusRunning);
+  EXPECT_EQ(TASK_RUNNING, statusRunning.get().state());
+
+  AWAIT_READY(statusFinished);
+  EXPECT_EQ(TASK_FINISHED, statusFinished.get().state());
+
+  driver.stop();
+  driver.join();
+
+  // The ContainerLogger spawns some helper processes that continue running
+  // briefly after the container finishes. Once they finish reading/writing
+  // the container's pipe, they should exit.
+  const Duration maxReapWaitTime = Seconds(30);
+  Try<os::ProcessTree> pstrees = os::pstree(0);
+  ASSERT_SOME(pstrees);
+  foreach (const os::ProcessTree& pstree, pstrees->children) {
+    // Wait for the logger subprocesses to exit, for up to 30 seconds each.
+    Duration waited = Duration::zero();
+    do {
+      if (!os::exists(pstree.process.pid)) {
+        break;
+      }
+
+      // Push the clock ahead to speed up the reaping of subprocesses.
+      Clock::pause();
+      Clock::settle();
+      Clock::advance(Seconds(1));
+      Clock::resume();
+
+      os::sleep(Milliseconds(100));
+      waited += Milliseconds(100);
+    } while (waited < maxReapWaitTime);
+
+    EXPECT_LE(waited, maxReapWaitTime);
+  }
+
+  // Check that the sandbox was written to.
+  std::string sandboxDirectory = path::join(
+      flags.work_dir,
+      "slaves",
+      offers.get()[0].slave_id().value(),
+      "frameworks",
+      frameworkId.get().value(),
+      "executors",
+      statusRunning->executor_id().value(),
+      "runs",
+      "latest");
+
+  ASSERT_TRUE(os::exists(sandboxDirectory));
+  const std::string stdoutPath = path::join(sandboxDirectory, "stdout");
+  ASSERT_TRUE(os::exists(stdoutPath));
+
+  // An associated logrotate config file should not exist.
+  const std::string configPath =
+    path::join(sandboxDirectory, "stdout.logrotate.conf");
+  ASSERT_FALSE(os::exists(configPath));
+
+  // Since some logs should have been rotated, the postrotate script should
+  // have created this file.
+  ASSERT_TRUE(os::exists(testFile));
 }
 
 


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This is the JournaldContainerLogger version of https://issues.apache.org/jira/browse/MESOS-9564,
which seals logrotate configuration files into MemFDs instead of writing them into a container's sandbox.

This also disables custom logrotate options via environment variables, as intended by this issue: 
https://issues.apache.org/jira/browse/MESOS-9576

The DC/OS documentation affected will be updated here:
https://github.com/mesosphere/dcos-docs-site/pull/2079

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS-47733](https://jira.mesosphere.com/browse/DCOS-47733) Disable modifications to container logger's custom logrotate options.
