### PR TITLE
Fluentbit integration

### DIFF
--- a/journald/journald.hpp
+++ b/journald/journald.hpp
@@ -41,12 +41,14 @@ struct Flags : public virtual flags::FlagsBase
         "destination_type",
         "Determines where logs should be piped.\n"
         "Valid destinations include: 'journald', 'logrotate',\n"
-        "or 'journald+logrotate'.",
+        "'fluentbit', 'journald+logrotate', or 'fluentbit+logrotate'.",
         "journald",
         [](const std::string& value) -> Option<Error> {
           if (value != "journald" &&
               value != "logrotate" &&
-              value != "journald+logrotate") {
+              value != "fluentbit" &&
+              value != "journald+logrotate" &&
+              value != "fluentbit+logrotate") {
             return Error("Invalid destination type: " + value);
           }
 
@@ -156,6 +158,21 @@ struct Flags : public virtual flags::FlagsBase
     add(&Flags::user,
         "user",
         "The user this command should run as.");
+
+    add(&Flags::fluentbit_ip,
+        "fluentbit_ip",
+        "IP of the Fluent Bit TCP listener.",
+        [](const Option<net::IP>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("--fluentbit_ip is required");
+          }
+
+          return None();
+        });
+
+    add(&Flags::fluentbit_port,
+        "fluentbit_port",
+        "Port of the Fluent Bit TCP listener.");
   }
 
   std::string destination_type;
@@ -170,6 +187,10 @@ struct Flags : public virtual flags::FlagsBase
   Option<std::string> logrotate_filename;
   std::string logrotate_path;
   Option<std::string> user;
+
+  // Only used if the `destination_type` has "fluentbit".
+  Option<net::IP> fluentbit_ip;
+  int fluentbit_port;
 };
 
 } // namespace logger {

--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -295,6 +295,8 @@ public:
     outFlags.user = containerConfig.has_user()
       ? Option<string>(containerConfig.user())
       : Option<string>::none();
+    outFlags.fluentbit_ip = flags.fluentbit_ip;
+    outFlags.fluentbit_port = flags.fluentbit_port;
 
     // If we are on systemd, then extend the life of the process as we
     // do with the executor. Any grandchildren's lives will also be
@@ -354,6 +356,8 @@ public:
     errFlags.user = containerConfig.has_user()
       ? Option<string>(containerConfig.user())
       : Option<string>::none();
+    errFlags.fluentbit_ip = flags.fluentbit_ip;
+    errFlags.fluentbit_port = flags.fluentbit_port;
 
     // Spawn a process to handle stderr.
     Try<Subprocess> errProcess = subprocess(

--- a/journald/lib_journald.hpp
+++ b/journald/lib_journald.hpp
@@ -11,6 +11,7 @@
 #include <stout/foreach.hpp>
 #include <stout/hashmap.hpp>
 #include <stout/json.hpp>
+#include <stout/net.hpp>
 #include <stout/option.hpp>
 
 #include <stout/os/exists.hpp>
@@ -36,12 +37,14 @@ struct LoggerFlags : public virtual flags::FlagsBase
         "destination_type",
         "Determines where logs should be piped.\n"
         "Valid destinations include: 'journald', 'logrotate',\n"
-        "or 'journald+logrotate'.",
+        "'fluentbit', 'journald+logrotate', or 'fluentbit+logrotate'.",
         "journald",
         [](const std::string& value) -> Option<Error> {
           if (value != "journald" &&
               value != "logrotate" &&
-              value != "journald+logrotate") {
+              value != "fluentbit" &&
+              value != "journald+logrotate" &&
+              value != "fluentbit+logrotate") {
             return Error("Invalid destination type: " + value);
           }
 
@@ -202,6 +205,22 @@ struct Flags : public virtual LoggerFlags
 
           return None();
         });
+
+
+    add(&Flags::fluentbit_ip,
+        "fluentbit_ip",
+        "IP of the Fluent Bit TCP listener.",
+        [](const Option<net::IP>& value) -> Option<Error> {
+          if (value.isNone()) {
+            return Error("--fluentbit_ip is required");
+          }
+
+          return None();
+        });
+
+    add(&Flags::fluentbit_port,
+        "fluentbit_port",
+        "Port of the Fluent Bit TCP listener.");
   }
 
   std::string environment_variable_prefix;
@@ -212,6 +231,9 @@ struct Flags : public virtual LoggerFlags
   Bytes max_label_payload_size;
 
   size_t libprocess_num_worker_threads;
+
+  Option<net::IP> fluentbit_ip;
+  int fluentbit_port;
 };
 
 

--- a/journald/modules.json.in
+++ b/journald/modules.json.in
@@ -15,6 +15,12 @@
             }, {
               "key": "destination_type",
               "value": "journald+logrotate"
+            }, {
+              "key": "fluentbit_ip",
+              "value": "127.0.0.1"
+            }, {
+              "key": "fluentbit_port",
+              "value": "5170"
             }
           ]
         }


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This adds an option to pipe log output over TCP, presumably to a fluentbit server running at a specified address.  In order to configure this properly, the fluentbit IP/Port **must** be added to the module parameters.  And the output mode should probably be set to `fluentbit+logrotate`:
https://github.com/dcos/dcos/blob/master/gen/dcos-config.yaml#L390-L412

The unit test does not require fluentbit as the pipeline is really just a TCP dump of log lines (albeit wrapped in JSON objects).

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS-50078](https://jira.mesosphere.com/browse/DCOS-50078) Integrate Mesos task logs with fluentbit component.
