### PR TITLE
Switched FileSink to the new LogSink interface (with usecs).

### DIFF
--- a/logsink/logsink.cpp
+++ b/logsink/logsink.cpp
@@ -60,7 +60,8 @@ void FileSink::send(
     int line,
     const struct ::tm* tm_time,
     const char* message,
-    size_t message_len)
+    size_t message_len,
+    google::int32 usecs)
 {
   os::write(
       logFd,
@@ -71,7 +72,24 @@ void FileSink::send(
           tm_time,
           message,
           // NOTE: The LogSink's message length excludes the newline.
-          message_len + 1));
+          message_len + 1,
+          usecs));
+}
+
+// This implements the send() method with the signature obsoleted in
+// MESOS-9687. The only reason why it is not empty is to provide
+// compatibility of the modules with the pre-MESOS-9687 Mesos code.
+void FileSink::send(
+    google::LogSeverity severity,
+    const char* full_filename,
+    const char* base_filename,
+    int line,
+    const struct ::tm* tm_time,
+    const char* message,
+    size_t message_len)
+{
+  send(severity, full_filename, base_filename, line, tm_time, message,
+       message_len, 0);
 }
 
 

--- a/logsink/logsink.hpp
+++ b/logsink/logsink.hpp
@@ -47,6 +47,22 @@ public:
       int line,
       const struct ::tm* tm_time,
       const char* message,
+      size_t message_len,
+      google::int32 usecs);
+
+  // This method implements the now obsolete LogSink interface without the
+  // `usecs` argument introduced by a glog patch in MESOS-9687.
+  //
+  // At the moment of writing defining this method is still necessary due
+  // to the need to maintain compatibility between glog and the old LogSink
+  // implementations.
+  virtual void send(
+      google::LogSeverity severity,
+      const char* full_filename,
+      const char* base_filename,
+      int line,
+      const struct ::tm* tm_time,
+      const char* message,
       size_t message_len);
 
   virtual void WaitTillSent();


### PR DESCRIPTION
## High-level description

This PR switches the FileSink in the logsink module to using the new LogSink interface added at https://issues.apache.org/jira/browse/MESOS-9687.

This finally solves the problem with zeroed microseconds in the logs which are written through this module:
https://jira.mesosphere.com/browse/DCOS-24365

Testing done: manually checked that there are microseconds in the DCOS built with this patch (build and DCOS integration tests: https://github.com/dcos/dcos/pull/4934)

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS-24365](https://jira.mesosphere.com/browse/DCOS-24365) Switched FileSink to the new LogSink interface (with microseconds).
