### PR TITLE
Made logging module use sandbox logging for DEBUG containers.

### DIFF
--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -77,6 +77,20 @@ public:
       const ContainerID& containerId,
       const ContainerConfig& containerConfig)
   {
+    if (containerConfig.has_container_class() &&
+        containerConfig.container_class() ==
+          mesos::slave::ContainerClass::DEBUG) {
+      ContainerIO io;
+
+      io.out = ContainerIO::IO::PATH(
+          path::join(containerConfig.directory(), "stdout"));
+
+      io.err = ContainerIO::IO::PATH(
+          path::join(containerConfig.directory(), "stderr"));
+
+      return io;
+    }
+
     // Prepare the environment for the container logger subprocess.
     // We inherit agent environment variables except for those
     // LIBPROCESS or MESOS prefixed environment variables. See MESOS-6747.


### PR DESCRIPTION
## High-level description

Perf traces from DC/OS agents running a considerable number of command
health checks showed that the agent spends a considerable amount of time
forking out processes to pipe the output of `DEBUG` containers to
journald.

`DEBUG` containers are mostly used by the default executor to run checks
and by operators using `dcos task exec` to run commands in interactive
sessions. The default executor already logs the output of the checks it
performs, and operators most probably don't expect the interactive
sessions logs to be sent to journald, so we decided to use sandbox
logging for `DEBUG` containers.

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS_OSS-5141](https://jira.mesosphere.com/browse/DCOS_OSS-5141) Pipe output of DEBUG containers to files in the container sandbox instead of to journald.
