### PR TITLE
Added metadata tagging to fluentbit logging mode.

### DIFF
--- a/journald/README.md
+++ b/journald/README.md
@@ -1,7 +1,7 @@
 # Journald Container Logger module
 
 The `JournaldContainerLogger` module takes all executor and tasks logs
-and pipes them to a configurable destination.  When the module was first 
+and pipes them to a configurable destination.  When the module was first
 written, it piped logs to the local systemd journald and so bears the name.
 However, in practice, using journald is *not recommended* due to scalability
 issues with the journald process.
@@ -80,7 +80,10 @@ Each line of logs is then wrapped in a JSON object (`{"line":"<log line>"}`)
 and written over the TCP connection.  This output mode does not attempt
 to retry if errors are encountered and will drop lines instead.
 
-> **NOTE**: The destination of the TCP connection is not specific to 
+The same labels sent to journald will also be included in the JSON object.
+See the Journald mode section above for specifics.
+
+> **NOTE**: The destination of the TCP connection is not specific to
 > Fluent Bit, as it is a plain TCP connection.  However, DC/OS uses
 > Fluent Bit, hence the mode's name.
 

--- a/journald/README.md
+++ b/journald/README.md
@@ -43,6 +43,17 @@ some information to make filtering and querying feasible:
 * `STREAM` == `STDOUT` or `STDERR`.
 * Any values in the `extra_labels` parameter passed to the module.
 
+The module flag `max_label_payload_size` is used to limit the total
+size of the metadata tagged with each log line.  Basic labels like the
+`*_ID`s and `STREAM` will always be included.  Other labels are copied
+(in no particular order) until the total size of the labels exceed the
+`max_label_payload_size`, or until all labels are copied.
+
+> **NOTE**: This limitation exists because labels and other flags are passed
+> to the logger's helper subprocesses as command line arguments.  On most
+> systems, the maximum length of command line arguments cannot exceed a
+> fixed value (usually 2 MB).
+
 For example, using `mesos-execute`:
 
 ```

--- a/tests/journald_tests.cpp
+++ b/tests/journald_tests.cpp
@@ -1052,7 +1052,17 @@ TEST_P(FluentbitLoggerTest, ROOT_LogToFluentbit)
 
   // From the server side, we don't actually know which connection is
   // stdout or stderr.  We expect the special string to be in stdout.
-  ASSERT_TRUE(strings::contains(data1.get() + data2.get(), specialString));
+  std::string combinedOutput = data1.get() + data2.get();
+  ASSERT_TRUE(strings::contains(combinedOutput, specialString));
+
+  // Log lines should also contain some metadata about the source of logs.
+  // We check for this summarily, since one of these outputs could be empty.
+  // And we don't want to implement a JSON object stream parser.
+  EXPECT_TRUE(strings::contains(combinedOutput, "FRAMEWORK_ID"));
+  EXPECT_TRUE(strings::contains(combinedOutput, "AGENT_ID"));
+  EXPECT_TRUE(strings::contains(combinedOutput, "EXECUTOR_ID"));
+  EXPECT_TRUE(strings::contains(combinedOutput, "CONTAINER_ID"));
+  EXPECT_TRUE(strings::contains(combinedOutput, "STREAM"));
 }
 
 


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This adds the same log metadata we currently add with `journald` logging, to `fluentbit` logging.  This includes tagging each line with various `*_ID`s and other labels found within a task's `ExecutorInfo`.

The README is adjusted to mention this.  Also, some existing behavior (`--max_label_payload_size`) is documented, which applies to both `journald` and `fluentbit` modes.

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS-52803](https://jira.mesosphere.com/browse/DCOS-52803) Enrich Fluentbit logging with Mesos metadata.
