### PR TITLE
Added test for logger behavior given DEBUG class containers.

### DIFF
--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -77,6 +77,11 @@ public:
       const ContainerID& containerId,
       const ContainerConfig& containerConfig)
   {
+    // DEBUG containers are associated with `LAUNCH_NESTED_CONTAINER_SESSION`
+    // calls and generally do not need extensive logging because their output
+    // is either temporary (i.e. health checks) or sent to the session starter
+    // (i.e. `dcos task exec`). Because forking logger subprocesses can be
+    // expensive, we simply log to sandbox for these container types.
     if (containerConfig.has_container_class() &&
         containerConfig.container_class() ==
           mesos::slave::ContainerClass::DEBUG) {


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This is a followup commit for #108 which adds a test exercising the change.

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS_OSS-5141](https://jira.mesosphere.com/browse/DCOS_OSS-5141) Pipe output of DEBUG containers to files in the container sandbox instead of to journald.
