### PR TITLE
Logsink: Minor fixups.

### DIFF
--- a/logsink/logsink.cpp
+++ b/logsink/logsink.cpp
@@ -37,7 +37,7 @@ FileSink::FileSink(const Flags& _flags) : flags(_flags)
   }
 
   // Open the file in append mode (or create it if it doesn't exist).
-  Try<int> open = os::open(
+  Try<int_fd> open = os::open(
       flags.output_file,
       O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC,
       S_IRUSR | S_IWUSR | S_IRGRP);
@@ -118,8 +118,8 @@ protected:
   process::Owned<FileSink> sink;
 };
 
-} // namespace mesos {
 } // namespace logsink {
+} // namespace mesos {
 
 
 Module<Anonymous> com_mesosphere_mesos_LogSink(

--- a/logsink/logsink.hpp
+++ b/logsink/logsink.hpp
@@ -69,11 +69,14 @@ public:
 
 protected:
   Flags flags;
-  int logFd;
+  int_fd logFd;
   std::recursive_mutex mutex;
 };
 
 } // namespace logsink {
 } // namespace mesos {
+
+extern mesos::modules::Module<mesos::modules::Anonymous>
+  com_mesosphere_mesos_LogSink;
 
 #endif // __LOGSINK_LOGSINK_HPP__


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This tweaks the logsink module in a couple small ways:
* The `int_fd` type is preferred when storing file descriptors.
* A namespace closing comment was incorrect.
* A harmless extern defined in the header would allow the module constructor to be called in other code, such as tests.

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

