### PR TITLE
Drop overlay master state records for agents that are gone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ cd build
 make
 ```
 
+In order to compile the Mesos modules tests, `--enable-tests-install`
+should be added to the `configure`'s command-line arguments too.
+
 ### Systemd journald headers
 
 Some of these modules also require systemd development headers and libraries.

--- a/overlay/overlay.proto
+++ b/overlay/overlay.proto
@@ -89,7 +89,7 @@ message AgentOverlayInfo {
 
   optional State state = 6;
 
-  //IPv6 subnet
+  // IPv6 subnet
   optional string subnet6 = 7;
 }
 


### PR DESCRIPTION
## High-level description

An HTTP endpoint should be introduced that accepts a list of agent IP addresses to remove from the Mesos overlay state. It is needed to drop such records for agents that are gone.

It is a backport of #113

## Changelog automation

[DCOS_OSS-5536](https://jira.mesosphere.com/browse/DCOS_OSS-5536) Mesos overlay networking: support dropping agents from the state
