### PR TITLE
Technology preview: statsd metrics isolator for Windows

### DIFF
--- a/metrics/isolator.hpp
+++ b/metrics/isolator.hpp
@@ -161,4 +161,6 @@ private:
 } // namespace dcos {
 } // namespace mesosphere {
 
+extern mesos::modules::Module<mesos::slave::Isolator> com_mesosphere_dcos_MetricsIsolatorModule;
+
 #endif // __METRICS_ISOLATOR_MODULE_HPP__

--- a/metrics/isolator.hpp
+++ b/metrics/isolator.hpp
@@ -76,18 +76,27 @@ struct Flags : virtual flags::FlagsBase
     add(&Flags::service_network,
         "dcos_metrics_service_network",
         "The network where the --dcos_metrics_service_address is reachable.\n"
+#ifndef __WINDOWS__
         "Must be either \"inet\" or \"unix\".",
+#else
+        "Must be \"inet\" on Windows.",
+#endif // __WINDOWS__
         [](const Option<std::string>& value) -> Option<Error> {
           if (value.isNone()) {
             return Error("Missing required option"
                          " --dcos_metrics_service_network");
           }
-
+#ifndef __WINDOWS__
+          if (value.get() != "inet") {
+            return Error("Expected --dcos_metrics_service_network"
+                         " to be \"inet\"");
+          }
+#else
           if (value.get() != "inet" && value.get() != "unix") {
             return Error("Expected --dcos_metrics_service_network"
                          " to be either \"inet\" or \"unix\"");
           }
-
+#endif // __WINDOWS__
           return None();
         });
 

--- a/tests/metrics_tests.cpp
+++ b/tests/metrics_tests.cpp
@@ -99,7 +99,15 @@ protected:
           } ]
         }
         )~",
+
+        // TODO(tillt): We need to rework this for Windows as soon as
+        // there are standalone modules on that platform.
+#ifndef __WINDOWS__
         path::join(MODULES_BUILD_DIR, ".libs", "libmetrics-module.so"),
+#else
+        "C:/fake/location/metrics-module.dll",
+#endif // __WINDOWS__
+
         ip + ":" + port,
         "/" + METRICS_PROCESS + "/" + API_PATH,
         stringify(REQUEST_TIMEOUT));


### PR DESCRIPTION
## High-level description

Ports the metrics isolator to a Windows compatible build.

This is a stop-gap solution until this module will officially be supported on Windows. This is not officially supported by D2iQ but a technology preview.

Removes the support for linux domain sockets on Windows for obvious reasons. It is yet to be determined if our pipeline supports or even mandates named pipes or alike instead.

## Changelog automation

**Note**: This section is intended for robots. Titles supplied in this template will be used as CHANGELOG entries for this patch - consider diverting from the original JIRA subject to fit this purpose.

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands. One line per entry, no length limit.

[DCOS-58008](https://jira.mesosphere.com/browse/DCOS-58008) Port the open source metrics module to Windows.
