### PR TITLE
journald logger fixups for linting and build time configuration.

### DIFF
--- a/journald/journald.cpp
+++ b/journald/journald.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include <vector>
 
-#ifndef __WINDOWS__
+#ifdef __linux__
 #include <sys/uio.h> // For `struct iovec`.
 
 #include <systemd/sd-journal.h>
-#endif // __WINDOWS__
+#endif // __linux__
 
 #include <process/address.hpp>
 #include <process/dispatch.hpp>
@@ -36,7 +36,7 @@
 using namespace process;
 using namespace mesos::journald::logger;
 
-#ifndef __WINDOWS__
+#ifdef __linux__
 // Forward declare a helper found in `src/linux/memfd.hpp`.
 namespace mesos {
 namespace internal {
@@ -48,7 +48,7 @@ Try<int_fd> create(const std::string& name, unsigned int flags);
 } // namespace memfd {
 } // namespace internal {
 } // namespace mesos {
-#endif // __WINDOWS__
+#endif // __linux__
 
 class JournaldLoggerProcess : public Process<JournaldLoggerProcess>
 {
@@ -77,7 +77,7 @@ public:
         "size " + stringify(flags.logrotate_max_size.bytes() - bufferSize) +
         "\n}";
 
-#ifndef __WINDOWS__
+#ifdef __linux__
       // Create a temporary anonymous file, which can be accessed by a child
       // process by opening a `/proc/self/fd/<FD of anonymous file>`.
       // This file is automatically removed on process termination, so we don't
@@ -117,7 +117,7 @@ public:
       if (result.isError()) {
         return Error("Failed to write configuration file: " + result.error());
       }
-#endif // __WINDOWS__
+#endif // __linux__
     }
 
     return new JournaldLoggerProcess(flags, configMemFd, bufferSize);
@@ -134,7 +134,7 @@ public:
       buffer = nullptr;
     }
 
-#ifndef __WINDOWS__
+#ifdef __linux__
     if (entries != nullptr) {
       for (int i = 0; i < num_entries - 1; i++) {
         if (entries != nullptr) {
@@ -146,7 +146,7 @@ public:
       delete[] entries;
       entries = nullptr;
     }
-#endif // __WINDOWS__
+#endif // __linux__
 
     if (leading.isSome()) {
       os::close(leading.get());
@@ -164,9 +164,9 @@ public:
   {
     // Pre-populate the `iovec` and `fluentbit_object` with the constant labels.
     num_entries = flags.parsed_labels.labels().size() + 1;
-#ifndef __WINDOWS__
+#ifdef __linux__
     entries = new struct iovec[num_entries];
-#endif // __WINDOWS__
+#endif // __linux__
 
     for (int i = 0; i < flags.parsed_labels.labels().size(); i++) {
       const mesos::Label& label = flags.parsed_labels.labels(i);
@@ -175,7 +175,7 @@ public:
       // Fluentbit is written as a JSON object.
       fluentbit_object.values[key] = label.value();
 
-#ifndef __WINDOWS__
+#ifdef __linux__
       // Journald requires conversion into the `iovec` structure,
       // which contains C-strings of concatenated key-values.
       const std::string entry = key + "=" + label.value();
@@ -184,7 +184,7 @@ public:
       entries[i].iov_len = entry.length();
       entries[i].iov_base = new char[entry.length() + 1];
       std::strcpy((char*) entries[i].iov_base, entry.c_str());
-#endif // __WINDOWS__
+#endif // __linux__
     }
 
     // NOTE: This is a prerequisuite for `io::read`.
@@ -212,7 +212,7 @@ public:
           return Nothing();
         }
 
-#ifndef __WINDOWS__
+#ifdef __linux__
         if (flags.destination_type == "journald" ||
             flags.destination_type == "journald+logrotate") {
           // Write the bytes to journald.
@@ -222,7 +222,7 @@ public:
             return Nothing();
           }
         }
-#endif // __WINDOWS__
+#endif // __linux__
 
         if (flags.destination_type == "logrotate" ||
             flags.destination_type == "journald+logrotate" ||
@@ -252,7 +252,7 @@ public:
       });
   }
 
-#ifndef __WINDOWS__
+#ifdef __linux__
   // Writes the buffer from stdin to the journald.
   // Any `flags.journald_labels` will be prepended to each line.
   Try<Nothing> write_journald(size_t readSize)
@@ -278,7 +278,7 @@ public:
     // Even if the write fails, we ignore the error.
     return Nothing();
   }
-#endif // __WINDOWS__
+#endif // __linux__
 
   // Writes the buffer from stdin to the leading log file.
   // When the number of written bytes exceeds `--logrotate_max_size`,
@@ -445,9 +445,9 @@ private:
   // which is changed each time we write to journald.
   int num_entries;
 
-#ifndef __WINDOWS__
+#ifdef __linux__
   struct iovec* entries;
-#endif // __WINDOWS__
+#endif // __linux__
 
   // The connection to the specified fluentbit address.
   Option<Try<int_fd>> fluentbit_socket;
@@ -495,7 +495,7 @@ int main(int argc, char** argv)
         "Failed to switch working directory for journald logger").message;
   }
 
-#ifndef __WINDOWS__
+#ifdef __linux__
   // If the `--user` flag is set, change the UID of this process to that user.
   if (flags.user.isSome()) {
     Try<Nothing> result = os::su(flags.user.get());
@@ -505,7 +505,7 @@ int main(int argc, char** argv)
         << ErrnoError("Failed to switch user for journald logger").message;
     }
   }
-#endif // __WINDOWS__
+#endif // __linux__
 
   // Asynchronously control the flow and size of logs.
   Try<JournaldLoggerProcess*> process = JournaldLoggerProcess::create(flags);

--- a/journald/journald.cpp
+++ b/journald/journald.cpp
@@ -129,22 +129,22 @@ public:
       os::close(configMemFd.get());
     }
 
-    if (buffer != NULL) {
+    if (buffer != nullptr) {
       delete[] buffer;
-      buffer = NULL;
+      buffer = nullptr;
     }
 
 #ifndef __WINDOWS__
-    if (entries != NULL) {
+    if (entries != nullptr) {
       for (int i = 0; i < num_entries - 1; i++) {
-        if (entries != NULL) {
+        if (entries != nullptr) {
           delete[] (char*) entries[i].iov_base;
-          entries[i].iov_base = NULL;
+          entries[i].iov_base = nullptr;
         }
       }
 
       delete[] entries;
-      entries = NULL;
+      entries = nullptr;
     }
 #endif // __WINDOWS__
 

--- a/journald/lib_journald.cpp
+++ b/journald/lib_journald.cpp
@@ -43,7 +43,7 @@ using mesos::slave::ContainerConfig;
 using mesos::slave::ContainerLogger;
 using mesos::slave::ContainerIO;
 
-#ifndef __WINDOWS__
+#ifdef __linux__
 // Forward declare some functions located in `src/linux/systemd.cpp`.
 // This is not exposed in the Mesos public headers, but is necessary to
 // keep the ContainerLogger's companion binaries alive if the agent dies.
@@ -57,7 +57,7 @@ Try<Nothing> extendLifetime(pid_t child);
 bool enabled();
 
 } // namespace systemd {
-#endif // __WINDOWS__
+#endif // __linux__
 
 namespace mesos {
 namespace journald {
@@ -325,12 +325,12 @@ public:
     // do with the executor. Any grandchildren's lives will also be
     // extended.
     std::vector<Subprocess::ParentHook> parentHooks;
-#ifndef __WINDOWS__
+#ifdef __linux__
     if (systemd::enabled()) {
       parentHooks.emplace_back(Subprocess::ParentHook(
           &systemd::mesos::extendLifetime));
     }
-#endif // __WINDOWS__
+#endif // __linux__
 
     // Spawn a process to handle stdout.
     Try<Subprocess> outProcess = subprocess(


### PR DESCRIPTION
## High-level description

Fixes linting problem on the use of `NULL` vs. `nullptr`. Updates the newly introduced OS specific build time function-set determination to an inclusive approach. 

No user facing changes were introduced.